### PR TITLE
Fix repository checkout when branch is set

### DIFF
--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -91,7 +91,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -85,13 +85,14 @@ Configure git.
 **Args:**
  
  - <b>`container`</b>:  the container to configure git for. 
- - <b>`custom_config_repository`</b>:  the git repository to add to known hosts. 
+ - <b>`custom_config_repository`</b>:  the git repository to add to known hosts in format 
+ - <b>`git+ssh`</b>: //<user>@<url>:<branch>. 
  - <b>`custom_config_ssh_key`</b>:  the SSH key for the git repository. 
 
 
 ---
 
-<a href="../src/wazuh.py#L126"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -91,7 +91,10 @@ def configure_git(
         custom_config_repository: the git repository to add to known hosts.
         custom_config_ssh_key: the SSH key for the git repository.
     """
-    hostname = custom_config_repository.split("@")[1].split("/")[0]
+    splitted_url = custom_config_repository.split("@")
+    hostname = splitted_url[1].split("/")[0]
+    url = "@".join(splitted_url[0:2])
+    branch = splitted_url[2] if len(splitted_url) > 2 else None
     process = container.exec(["ssh-keyscan", "-t", "rsa", hostname])
     output, _ = process.wait_output()
     container.push(
@@ -112,7 +115,11 @@ def configure_git(
         group=WAZUH_GROUP,
         permissions=0o600,
     )
-    process = container.exec(["git", "clone", custom_config_repository, REPOSITORY_PATH])
+    command = ["git", "clone"]
+    if branch:
+        command = command + ["--branch", branch]
+    command = command + [url, REPOSITORY_PATH]
+    process = container.exec(command)
     process.wait_output()
 
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -88,12 +88,13 @@ def configure_git(
 
     Args:
         container: the container to configure git for.
-        custom_config_repository: the git repository to add to known hosts.
+        custom_config_repository: the git repository to add to known hosts in format
+        git+ssh://<user>@<url>:<branch>.
         custom_config_ssh_key: the SSH key for the git repository.
     """
     splitted_url = custom_config_repository.split("@")
-    hostname = splitted_url[1].split("/")[0]
     url = "@".join(splitted_url[0:2])
+    hostname = splitted_url[1].split("/")[0]
     branch = splitted_url[2] if len(splitted_url) > 2 else None
     process = container.exec(["ssh-keyscan", "-t", "rsa", hostname])
     output, _ = process.wait_output()

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -103,10 +103,10 @@ def test_install_certificates() -> None:
     )
 
 
-def test_configure_git() -> None:
+def test_configure_git_when_branch_specified() -> None:
     """
     arrange: do nothing.
-    act: configure git.
+    act: configure git specifying a branch name.
     assert: the files have been saved with the appropriate content.
     """
     harness = Harness(ops.CharmBase, meta=CHARM_METADATA)
@@ -115,7 +115,45 @@ def test_configure_git() -> None:
     )
     custom_config_repository = "git+ssh://user1@git.server/repo_name@main"
     harness.handle_exec(
-        "wazuh-server", ["git", "clone", custom_config_repository, "/root/repository"], result=""
+        "wazuh-server",
+        [
+            "git",
+            "clone",
+            "--branch",
+            "main",
+            "git+ssh://user1@git.server/repo_name",
+            "/root/repository",
+        ],
+        result="",
+    )
+    harness.begin_with_initial_hooks()
+    container = harness.charm.unit.get_container("wazuh-server")
+    custom_config_ssh_key = "somekey"
+    wazuh.configure_git(container, custom_config_repository, custom_config_ssh_key)
+    assert "know_host" == container.pull(wazuh.KNOWN_HOSTS_PATH, encoding="utf-8").read()
+    assert "somekey" == container.pull(wazuh.RSA_PATH, encoding="utf-8").read()
+
+
+def test_configure_git_when_no_branch_specified() -> None:
+    """
+    arrange: do nothing.
+    act: configure git without specifying a branch name.
+    assert: the files have been saved with the appropriate content.
+    """
+    harness = Harness(ops.CharmBase, meta=CHARM_METADATA)
+    harness.handle_exec(
+        "wazuh-server", ["ssh-keyscan", "-t", "rsa", "git.server"], result="know_host"
+    )
+    custom_config_repository = "git+ssh://user1@git.server/repo_name"
+    harness.handle_exec(
+        "wazuh-server",
+        [
+            "git",
+            "clone",
+            "git+ssh://user1@git.server/repo_name",
+            "/root/repository",
+        ],
+        result="",
     )
     harness.begin_with_initial_hooks()
     container = harness.charm.unit.get_container("wazuh-server")


### PR DESCRIPTION
Applicable spec: <link>
N/A

### Overview

<!-- A high level overview of the change -->
Fix repository checkout when the branch is set as part of the repository URL

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
wazuh.py

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
