### PR TITLE
Fix: remove repository when repository configuration is unset

### DIFF
--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L35"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -41,7 +41,7 @@ Update Wazuh configuration.
 
 ---
 
-<a href="../src/wazuh.py#L73"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -66,15 +66,15 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L123"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L127"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
 ```python
 configure_git(
     container: Container,
-    custom_config_repository: str,
-    custom_config_ssh_key: str
+    custom_config_repository: Optional[str],
+    custom_config_ssh_key: Optional[str]
 ) → None
 ```
 
@@ -92,7 +92,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L173"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L185"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,12 +91,16 @@ class WazuhServerCharm(CharmBaseWithState):
             self.certificates.private_key,
             self.state.certificate,
         )
+        wazuh.configure_git(
+            container,
+            (
+                str(self.state.custom_config_repository)
+                if self.state.custom_config_repository
+                else None
+            ),
+            self.state.custom_config_ssh_key,
+        )
         if self.state.custom_config_repository:
-            wazuh.configure_git(
-                container,
-                str(self.state.custom_config_repository),
-                self.state.custom_config_ssh_key,
-            )
             wazuh.pull_configuration_files(container)
         wazuh.update_configuration(container, self.state.indexer_ips)
         container.add_layer("wazuh", self._pebble_layer, combine=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,11 +76,13 @@ def test_reconcile_reaches_active_status_when_repository_configured(
 
 @patch.object(State, "from_charm")
 @patch.object(wazuh, "configure_git")
+@patch.object(wazuh, "pull_configuration_files")
 @patch.object(wazuh, "update_configuration")
 @patch.object(wazuh, "install_certificates")
 def test_reconcile_reaches_active_status_when_repository_not_configured(
     wazuh_install_certificates_mock,
     wazuh_update_configuration_mock,
+    pull_configuration_files_mock,
     configure_git_mock,
     state_from_charm_mock,
 ):
@@ -105,7 +107,8 @@ def test_reconcile_reaches_active_status_when_repository_not_configured(
 
     wazuh_install_certificates_mock.assert_called_with(container, ANY, "somecert")
     wazuh_update_configuration_mock.assert_called_with(container, ["10.0.0.1"])
-    configure_git_mock.assert_not_called()
+    configure_git_mock.assert_called_with(container, None, None)
+    pull_configuration_files_mock.assert_not_called()
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -188,7 +188,7 @@ def test_configure_git_when_no_branch_specified() -> None:
 def test_configure_git_when_no_key_no_repository_specified() -> None:
     """
     arrange: do nothing.
-    act: configure git without specifying a branch name.
+    act: configure git without specifying a repository.
     assert: the files have been saved with the appropriate content.
     """
     harness = Harness(ops.CharmBase, meta=CHARM_METADATA)

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -183,3 +183,28 @@ def test_configure_git_when_no_branch_specified() -> None:
     wazuh.configure_git(container, custom_config_repository, custom_config_ssh_key)
     assert "know_host" == container.pull(wazuh.KNOWN_HOSTS_PATH, encoding="utf-8").read()
     assert "somekey" == container.pull(wazuh.RSA_PATH, encoding="utf-8").read()
+
+
+def test_configure_git_when_no_key_no_repository_specified() -> None:
+    """
+    arrange: do nothing.
+    act: configure git without specifying a branch name.
+    assert: the files have been saved with the appropriate content.
+    """
+    harness = Harness(ops.CharmBase, meta=CHARM_METADATA)
+    harness.handle_exec(
+        "wazuh-server",
+        ["git", "-C", wazuh.REPOSITORY_PATH, "config", "--get", "remote.origin.url"],
+        result="",
+    )
+    harness.handle_exec(
+        "wazuh-server",
+        ["git", "-C", wazuh.REPOSITORY_PATH, "rev-parse", "--abbrev-ref", "HEAD"],
+        result="",
+    )
+    harness.handle_exec("wazuh-server", ["rm", "-rf", wazuh.REPOSITORY_PATH], result="")
+    harness.begin_with_initial_hooks()
+    container = harness.charm.unit.get_container("wazuh-server")
+    wazuh.configure_git(container, None, None)
+    assert not container.exists(wazuh.KNOWN_HOSTS_PATH)
+    assert not container.exists(wazuh.RSA_PATH)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Remove repository when repository configuration is unset

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
charm.py
wazuh.py

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
