### PR TITLE
Fix: remove repository when repository configuration is unset

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -173,13 +173,13 @@ def configure_git(
         process = container.exec(["rm", "-rf", REPOSITORY_PATH])
         process.wait_output()
 
-    if base_url:
-        command = ["git", "clone"]
-        if branch:
-            command = command + ["--branch", branch]
-        command = command + [base_url, REPOSITORY_PATH]
-        process = container.exec(command)
-        process.wait_output()
+        if base_url:
+            command = ["git", "clone"]
+            if branch:
+                command = command + ["--branch", branch]
+            command = command + [base_url, REPOSITORY_PATH]
+            process = container.exec(command)
+            process.wait_output()
 
 
 def pull_configuration_files(container: ops.Container) -> None:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Follow up #16 

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
