### PR TITLE
Fix configuration pulling

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -189,7 +189,7 @@ def pull_configuration_files(container: ops.Container) -> None:
         container: the container to pull the files into.
     """
     try:
-        process = container.exec(["git", "--git-dir" f"{REPOSITORY_PATH}/.git", "pull"])
+        process = container.exec(["git", "--git-dir", f"{REPOSITORY_PATH}/.git", "pull"])
         process.wait_output()
         process = container.exec(
             [


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix configuration repository pulling

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
wazuh.py

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
