### PR TITLE
Do not verify the indexer's SSL certificate

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -28,6 +28,8 @@ parts:
       - ssh
   filebeat:
     plugin: nil
+    build-packages:
+      - yq
     stage-packages:
       - filebeat
       - net-tools

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -35,6 +35,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/etc/filebeat/certs
       chmod 500 $CRAFT_PART_INSTALL/etc/filebeat/certs
       curl --max-time 60 -o $CRAFT_PART_INSTALL/etc/filebeat/filebeat.yml https://packages.wazuh.com/4.8/tpl/wazuh/filebeat/filebeat.yml
+      yq -iy '."output.elasticsearch"."ssl.verification_mode"=false' $CRAFT_PART_INSTALL/etc/filebeat/filebeat.yml
       mkdir -p $CRAFT_PART_INSTALL/usr/share/filebeat/module
       curl --max-time 60 https://packages.wazuh.com/4.x/filebeat/wazuh-filebeat-0.4.tar.gz | tar -xvz -C $CRAFT_PART_INSTALL/usr/share/filebeat/module
       curl --max-time 60 -o $CRAFT_PART_INSTALL/etc/filebeat/wazuh-template.json https://raw.githubusercontent.com/wazuh/wazuh/v4.8.1/extensions/elasticsearch/7.x/wazuh-template.json


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Do not verify the indexer's SSL certificate. It can be self signed

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
