### PR TITLE
Copy only configuration files from the customization repository

### DIFF
--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -113,7 +113,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L225"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -205,7 +205,15 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "-ra",
                 "--chown",
                 "wazuh:wazuh",
-                f"{REPOSITORY_PATH}/var/ossec/",
+                "--include='*/'",
+                "--include 'etc/*.conf'",
+                "--include 'etc/decoders/***'",
+                "--include 'etc/rules/***'",
+                "--include 'etc/shared/*.conf'",
+                "--include 'etc/shared/**/*.conf'",
+                "--include 'integrations/***'",
+                "--exclude '*'",
+                "/root/repository/var/ossec/",
                 "/var/ossec",
             ]
         )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Copy only configuration files from the customization repository to avoid overwriting files from the Wazuh installation:
etc/*.conf
etc/decoders/*
etc/rules/*
etc/shared/[**/]*.conf
integrations/*

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
