### PR TITLE
Revert "Use filebeat CA for agent enrollment (#32)"

### DIFF
--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L40"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L39"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -41,7 +41,7 @@ Update Wazuh configuration.
 
 ---
 
-<a href="../src/wazuh.py#L85"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L77"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -68,7 +68,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L143"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L135"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -94,7 +94,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L201"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L193"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -113,7 +113,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L233"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L225"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -36,7 +36,6 @@ class WazuhInstallationError(Exception):
     """Base exception for Wazuh errors."""
 
 
-# pylint: disable=too-many-locals
 def update_configuration(container: ops.Container, indexer_ips: list[str]) -> None:
     """Update Wazuh configuration.
 
@@ -62,13 +61,6 @@ def update_configuration(container: ops.Container, indexer_ips: list[str]) -> No
         new_host = etree.Element("host")
         new_host.text = f"https://{ip_port}"
         hosts[0].append(new_host)
-    new_ssl_agent_ca = etree.Element("ssl_agent_ca")
-    new_ssl_agent_ca.text = str(CERTIFICATES_PATH / "root-ca.pem")
-    ssl_agent_ca = ossec_config_tree.xpath("/root/ossec_config/auth/ssl_agent_ca")
-    if ssl_agent_ca:
-        ssl_agent_ca[0].get_parent().remove(ssl_agent_ca[0])
-    auth = ossec_config_tree.xpath("/root/ossec_config/auth")
-    auth[0].append(new_ssl_agent_ca)
     elements = ossec_config_tree.xpath("//ossec_config")
     content = b""
     for element in elements:

--- a/tests/unit/resources/ossec.conf
+++ b/tests/unit/resources/ossec.conf
@@ -12,20 +12,6 @@
       <key>/etc/filebeat/certs/filebeat-key.pem</key>
     </ssl>
   </indexer>
-  <!-- Configuration for wazuh-authd -->
-  <auth>
-    <disabled>no</disabled>
-    <port>1515</port>
-    <use_source_ip>no</use_source_ip>
-    <purge>yes</purge>
-    <use_password>no</use_password>
-    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
-    <!-- <ssl_agent_ca></ssl_agent_ca> -->
-    <ssl_verify_host>no</ssl_verify_host>
-    <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
-    <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
-    <ssl_auto_negotiate>no</ssl_auto_negotiate>
-  </auth>
 </ossec_config>
 <ossec_config>
   <placeholder/>

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -22,7 +22,6 @@ containers:
 """
 
 
-# pylint: disable=too-many-locals
 def test_update_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     arrange: copy the Wazuh configuration files into a container and mock the service restart.
@@ -55,8 +54,6 @@ def test_update_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(hosts) == len(indexer_ips)
     for idx, host in enumerate(hosts):
         assert host.text == f"https://{indexer_ips[idx]}"
-    auth_ca = tree.xpath("/root/ossec_config/auth/ssl_agent_ca")
-    assert str(wazuh.CERTIFICATES_PATH / "root-ca.pem") == auth_ca[0].text
 
 
 def test_update_configuration_when_restart_fails(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
This reverts commit 626febc4faa0be2de698c9a03329bd5b49c8fda8.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->
We'll be using password authentication instead

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
