### PR TITLE
Secure Wazuh API

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,6 +24,6 @@ jobs:
       zap-enabled: false
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      self-hosted-runner: true
+      self-hosted-runner: false
       self-hosted-runner-label: "xlarge"
       microk8s-addons: "dns ingress rbac storage registry"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,6 +24,6 @@ jobs:
       zap-enabled: false
       trivy-fs-enabled: true
       trivy-image-config: "trivy.yaml"
-      self-hosted-runner: false
+      self-hosted-runner: true
       self-hosted-runner-label: "xlarge"
       microk8s-addons: "dns ingress rbac storage registry"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -101,6 +101,7 @@ config:
       description: >
         The Juju secret ID corresponding to the password used by the wazuh API.
         Once set, it can't be changed. This configuration is only applied the first time the charm is installed.
+        The password must contain at least one upper and lower case letter, a number and a symbol.
     custom-config-repository:
       type: string
       description: >

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -100,6 +100,7 @@ config:
       type: secret
       description: >
         The Juju secret ID corresponding to the password used by the wazuh API.
+        Once set, it can't be changed. This configuration is only applied the first time the charm is installed.
     custom-config-repository:
       type: string
       description: >

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -96,12 +96,6 @@ config:
       type: secret
       description: >
         The Juju secret ID corresponding to the password used by the agents to connect to Wazuh.
-    api-password:
-      type: secret
-      description: >
-        The Juju secret ID corresponding to the password used by the wazuh API.
-        Once set, it can't be changed. This configuration is only applied the first time the charm is installed.
-        The password must contain at least one upper and lower case letter, a number and a symbol.
     custom-config-repository:
       type: string
       description: >

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -7,6 +7,7 @@ Wazuh server charm.
 
 **Global Variables**
 ---------------
+- **WAZUH_API_CREDENTIALS**
 - **WAZUH_CLUSTER_KEY_SECRET_LABEL**
 - **WAZUH_DEFAULT_API_CREDENTIALS**
 - **WAZUH_PEER_RELATION_NAME**
@@ -24,7 +25,7 @@ Charm the service.
  - <b>`fqdns`</b>:  the unit FQDNs. 
  - <b>`state`</b>:  the charm state. 
 
-<a href="../src/charm.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L43"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -95,7 +96,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -7,6 +7,7 @@ Wazuh server charm.
 
 **Global Variables**
 ---------------
+- **WAZUH_API_CREDENTIALS**
 - **WAZUH_CLUSTER_KEY_SECRET_LABEL**
 - **WAZUH_PEER_RELATION_NAME**
 
@@ -23,7 +24,7 @@ Charm the service.
  - <b>`fqdns`</b>:  the unit FQDNs. 
  - <b>`state`</b>:  the charm state. 
 
-<a href="../src/charm.py#L41"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -94,7 +95,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -81,7 +81,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -7,8 +7,8 @@ Wazuh server charm.
 
 **Global Variables**
 ---------------
-- **WAZUH_API_CREDENTIALS**
 - **WAZUH_CLUSTER_KEY_SECRET_LABEL**
+- **WAZUH_DEFAULT_API_CREDENTIALS**
 - **WAZUH_PEER_RELATION_NAME**
 
 
@@ -95,7 +95,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L105"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L92"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -23,7 +23,7 @@ Charm the service.
  - <b>`fqdns`</b>:  the unit FQDNs. 
  - <b>`state`</b>:  the charm state. 
 
-<a href="../src/charm.py#L42"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L41"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -94,7 +94,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -18,7 +18,7 @@ Charm the service.
  
  - <b>`state`</b>:  the charm state. 
 
-<a href="../src/charm.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -81,7 +81,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L98"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L101"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -94,7 +94,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L94"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L91"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -94,7 +94,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/charm.py#L128"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/charm.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -7,6 +7,7 @@ Wazuh server charm state.
 
 **Global Variables**
 ---------------
+- **WAZUH_API_CREDENTIALS**
 - **WAZUH_CLUSTER_KEY_SECRET_LABEL**
 
 
@@ -56,7 +57,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/state.py#L26"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -134,7 +135,7 @@ The Wazuh server charm state.
 **Attributes:**
  
  - <b>`agent_password`</b>:  the agent password. 
- - <b>`api_password`</b>:  the API password. 
+ - <b>`api_credentials`</b>:  a map containing the API credentials. 
  - <b>`cluster_key`</b>:  the Wazuh key for the cluster nodes. 
  - <b>`indexer_ips`</b>:  list of Wazuh indexer IPs. 
  - <b>`filebeat_username`</b>:  the filebeat username. 
@@ -145,14 +146,14 @@ The Wazuh server charm state.
  - <b>`custom_config_ssh_key`</b>:  the SSH key for the git repository. 
  - <b>`proxy`</b>:  proxy configuration. 
 
-<a href="../src/state.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L237"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
 ```python
 __init__(
     agent_password: str | None,
-    api_password: str,
+    api_credentials: dict[str, str],
     cluster_key: str,
     indexer_ips: list[str],
     filebeat_username: str,
@@ -171,7 +172,7 @@ Initialize a new instance of the CharmState class.
 **Args:**
  
  - <b>`agent_password`</b>:  the agent password. 
- - <b>`api_password`</b>:  the API password. 
+ - <b>`api_credentials`</b>:  a map ccontaining the API credentials. 
  - <b>`cluster_key`</b>:  the Wazuh key for the cluster nodes. 
  - <b>`indexer_ips`</b>:  list of Wazuh indexer IPs. 
  - <b>`filebeat_username`</b>:  the filebeat username. 
@@ -225,7 +226,7 @@ Get charm proxy configuration from juju charm environment.
 
 ---
 
-<a href="../src/state.py#L279"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L299"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 
@@ -272,7 +273,6 @@ The Wazuh server charm configuration.
 **Attributes:**
  
  - <b>`agent_password`</b>:  the secret key corresponding to the agent secret. 
- - <b>`api_password`</b>:  the secret key corresponding to the wazuh API secret. 
  - <b>`custom_config_repository`</b>:  the git repository where the configuration is. 
  - <b>`custom_config_ssh_key`</b>:  the secret key corresponding to the SSH key for the git repository. 
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -9,6 +9,7 @@ Wazuh server charm state.
 ---------------
 - **WAZUH_API_CREDENTIALS**
 - **WAZUH_CLUSTER_KEY_SECRET_LABEL**
+- **WAZUH_DEFAULT_API_CREDENTIALS**
 
 
 ---
@@ -57,7 +58,7 @@ Unit that this execution is responsible for.
 
 ---
 
-<a href="../src/state.py#L27"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `reconcile`
 
@@ -138,6 +139,7 @@ The Wazuh server charm state.
  - <b>`api_credentials`</b>:  a map containing the API credentials. 
  - <b>`cluster_key`</b>:  the Wazuh key for the cluster nodes. 
  - <b>`indexer_ips`</b>:  list of Wazuh indexer IPs. 
+ - <b>`is_default_api_password`</b>:  if the default API password is in use. 
  - <b>`filebeat_username`</b>:  the filebeat username. 
  - <b>`filebeat_password`</b>:  the filebeat password. 
  - <b>`certificate`</b>:  the TLS certificate. 
@@ -146,7 +148,7 @@ The Wazuh server charm state.
  - <b>`custom_config_ssh_key`</b>:  the SSH key for the git repository. 
  - <b>`proxy`</b>:  proxy configuration. 
 
-<a href="../src/state.py#L237"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L243"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 
@@ -182,6 +184,14 @@ Initialize a new instance of the CharmState class.
  - <b>`wazuh_config`</b>:  Wazuh configuration. 
  - <b>`custom_config_ssh_key`</b>:  the SSH key for the git repository. 
 
+
+---
+
+#### <kbd>property</kbd> is_default_api_password
+
+Check if the default API password is in use.. 
+
+Returns: True if the current password is the default 
 
 ---
 
@@ -226,7 +236,7 @@ Get charm proxy configuration from juju charm environment.
 
 ---
 
-<a href="../src/state.py#L299"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/state.py#L305"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>classmethod</kbd> `from_charm`
 

--- a/src-docs/state.py.md
+++ b/src-docs/state.py.md
@@ -139,7 +139,7 @@ The Wazuh server charm state.
 ```python
 __init__(
     agent_password: str | None,
-    api_password: str | None,
+    api_password: str,
     indexer_ips: list[str],
     filebeat_username: str,
     filebeat_password: str,

--- a/src-docs/traefik_route_observer.py.md
+++ b/src-docs/traefik_route_observer.py.md
@@ -22,7 +22,7 @@ The Traefik route relation observer.
  
  - <b>`hostname`</b>:  The unit's hostname. 
 
-<a href="../src/traefik_route_observer.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/traefik_route_observer.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -50,7 +50,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L138"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -77,7 +77,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -97,7 +97,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L213"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -123,7 +123,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L275"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -142,7 +142,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L303"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L307"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -167,7 +167,7 @@ Configure the filebeat user.
 
 ---
 
-<a href="../src/wazuh.py#L359"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L363"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_api_password`
 
@@ -189,6 +189,7 @@ Change Wazuh's API password for a given user.
 
 **Raises:**
  
+ - <b>`WazuhAuthenticationError`</b>:  if an authentication error occurs. 
  - <b>`WazuhInstallationError`</b>:  if an error occurs while processing the requests. 
 
 
@@ -198,6 +199,15 @@ Change Wazuh's API password for a given user.
 Enum for the Wazuh node types. 
 
 Attrs:  WORKER: worker.  MASTER: master. 
+
+
+
+
+
+---
+
+## <kbd>class</kbd> `WazuhAuthenticationError`
+Wazuh authentication errors. 
 
 
 

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L110"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L109"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -50,7 +50,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L138"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -77,7 +77,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L158"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -97,7 +97,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L214"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L213"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -123,7 +123,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L272"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L271"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -142,7 +142,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L303"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -167,12 +167,12 @@ Configure the filebeat user.
 
 ---
 
-<a href="../src/wazuh.py#L360"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L359"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_api_password`
 
 ```python
-change_api_password(old_password: str, new_password: str) → None
+change_api_password(username: str, old_password: str, new_password: str) → None
 ```
 
 Change Wazuh's API password for the default 'wazuh' user. 
@@ -181,8 +181,9 @@ Change Wazuh's API password for the default 'wazuh' user.
 
 **Args:**
  
- - <b>`old_password`</b>:  the old API password for the 'wazuh' user. 
- - <b>`new_password`</b>:  the new API password for the 'wazuh' user. 
+ - <b>`username`</b>:  the username to change the user for. 
+ - <b>`old_password`</b>:  the old API password for the user. 
+ - <b>`new_password`</b>:  the new API password for the user. 
 
 
 

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -10,13 +10,12 @@ Wazuh operational logic.
 - **KNOWN_HOSTS_PATH**
 - **RSA_PATH**
 - **REPOSITORY_PATH**
-- **WAZUH_DEFAULT_CREDENTIALS**
 - **WAZUH_GROUP**
 - **WAZUH_USER**
 
 ---
 
-<a href="../src/wazuh.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -51,7 +50,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -78,7 +77,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L166"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -98,7 +97,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -124,7 +123,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L281"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L279"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -143,7 +142,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L313"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L311"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -168,7 +167,7 @@ Configure the filebeat user.
 
 ---
 
-<a href="../src/wazuh.py#L369"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L367"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_api_password`
 
@@ -196,17 +195,37 @@ Change Wazuh's API password for a given user.
 
 ---
 
-<a href="../src/wazuh.py#L422"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L429"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-## <kbd>function</kbd> `generate_api_password`
+## <kbd>function</kbd> `generate_api_credentials`
 
 ```python
-generate_api_password() → str
+generate_api_credentials() → dict[str, str]
 ```
 
-Generate a password that complies with the API password imposed by Wazuh. 
+Generate the credentials for the default API users. 
 
-Returns: a string with a compliant password. 
+Returns: a dict containing the new credentials. 
+
+
+---
+
+<a href="../src/wazuh.py#L440"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `store_api_credentials`
+
+```python
+store_api_credentials(app: Application, credentials: dict[str, str]) → None
+```
+
+Store the wazuh API credentials in a secret. 
+
+
+
+**Args:**
+ 
+ - <b>`app`</b>:  the Juju application. 
+ - <b>`credentials`</b>:  the API credentials to store. 
 
 
 ---

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -7,15 +7,16 @@ Wazuh operational logic.
 
 **Global Variables**
 ---------------
-- **WAZUH_USER**
-- **WAZUH_GROUP**
 - **KNOWN_HOSTS_PATH**
 - **RSA_PATH**
 - **REPOSITORY_PATH**
+- **WAZUH_DEFAULT_CREDENTIALS**
+- **WAZUH_GROUP**
+- **WAZUH_USER**
 
 ---
 
-<a href="../src/wazuh.py#L113"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L119"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -50,7 +51,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L142"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L148"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -77,7 +78,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L162"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L168"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -97,7 +98,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L217"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L223"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -123,7 +124,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L275"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L281"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -142,7 +143,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L307"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L313"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -167,7 +168,7 @@ Configure the filebeat user.
 
 ---
 
-<a href="../src/wazuh.py#L363"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L369"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_api_password`
 
@@ -191,6 +192,21 @@ Change Wazuh's API password for a given user.
  
  - <b>`WazuhAuthenticationError`</b>:  if an authentication error occurs. 
  - <b>`WazuhInstallationError`</b>:  if an error occurs while processing the requests. 
+
+
+---
+
+<a href="../src/wazuh.py#L422"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `generate_api_password`
+
+```python
+generate_api_password() → str
+```
+
+Generate a password that complies with the API password imposed by Wazuh. 
+
+Returns: a string with a compliant password. 
 
 
 ---

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L108"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L110"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -50,7 +50,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L137"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -77,7 +77,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L157"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -97,7 +97,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L212"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L214"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -123,7 +123,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L270"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L272"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -142,7 +142,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L302"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L304"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -163,6 +163,32 @@ Configure the filebeat user.
  - <b>`container`</b>:  the container to configure the user for. 
  - <b>`username`</b>:  the username. 
  - <b>`password`</b>:  the password. 
+
+
+---
+
+<a href="../src/wazuh.py#L360"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `change_api_password`
+
+```python
+change_api_password(old_password: str, new_password: str) → None
+```
+
+Change Wazuh's API password for the default 'wazuh' user. 
+
+
+
+**Args:**
+ 
+ - <b>`old_password`</b>:  the old API password for the 'wazuh' user. 
+ - <b>`new_password`</b>:  the new API password for the 'wazuh' user. 
+
+
+
+**Raises:**
+ 
+ - <b>`WazuhInstallationError`</b>:  if an error occurs while processing the requests. 
 
 
 ---

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L117"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -50,7 +50,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L146"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -77,7 +77,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L166"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L164"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -97,7 +97,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L219"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -123,7 +123,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L279"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -142,7 +142,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L311"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L309"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -167,7 +167,7 @@ Configure the filebeat user.
 
 ---
 
-<a href="../src/wazuh.py#L367"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L365"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_api_password`
 
@@ -195,7 +195,7 @@ Change Wazuh's API password for a given user.
 
 ---
 
-<a href="../src/wazuh.py#L431"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L429"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_api_credentials`
 

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -175,7 +175,7 @@ Configure the filebeat user.
 change_api_password(username: str, old_password: str, new_password: str) → None
 ```
 
-Change Wazuh's API password for the default 'wazuh' user. 
+Change Wazuh's API password for a given user. 
 
 
 

--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -195,7 +195,7 @@ Change Wazuh's API password for a given user.
 
 ---
 
-<a href="../src/wazuh.py#L429"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L431"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_api_credentials`
 
@@ -206,26 +206,6 @@ generate_api_credentials() → dict[str, str]
 Generate the credentials for the default API users. 
 
 Returns: a dict containing the new credentials. 
-
-
----
-
-<a href="../src/wazuh.py#L440"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
-
-## <kbd>function</kbd> `store_api_credentials`
-
-```python
-store_api_credentials(app: Application, credentials: dict[str, str]) → None
-```
-
-Store the wazuh API credentials in a secret. 
-
-
-
-**Args:**
- 
- - <b>`app`</b>:  the Juju application. 
- - <b>`credentials`</b>:  the API credentials to store. 
 
 
 ---

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ import opensearch_observer
 import traefik_route_observer
 import wazuh
 from state import (
+    WAZUH_API_CREDENTIALS,
     WAZUH_CLUSTER_KEY_SECRET_LABEL,
     WAZUH_DEFAULT_API_CREDENTIALS,
     CharmBaseWithState,
@@ -104,7 +105,6 @@ class WazuhServerCharm(CharmBaseWithState):
             return
         if not self.state:
             return
-        self.unit.status = ops.MaintenanceStatus()
         wazuh.install_certificates(
             container=self.unit.containers.get("wazuh-server"),
             private_key=self.certificates.private_key,
@@ -142,7 +142,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 wazuh.change_api_password(
                     username, WAZUH_DEFAULT_API_CREDENTIALS[username], password
                 )
-            wazuh.store_api_credentials(self.app, credentials)
+            self.app.add_secret(credentials, label=WAZUH_API_CREDENTIALS)
         self.unit.status = ops.ActiveStatus()
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,11 +55,8 @@ class WazuhServerCharm(CharmBaseWithState):
         self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_joined, self.reconcile)
         self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_changed, self.reconcile)
 
-    def _on_install(self, event: ops.InstallEvent) -> None:
+    def _on_install(self, _: ops.InstallEvent) -> None:
         """Install event handler."""
-        if not self.state:
-            event.defer()
-            return
         if self.unit.is_leader():
             try:
                 self.model.get_secret(label=WAZUH_CLUSTER_KEY_SECRET_LABEL)

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,10 +54,10 @@ class WazuhServerCharm(CharmBaseWithState):
         """Config changed handler."""
         self.reconcile()
 
-    def _on_install(self, _: ops.InstallEvent) -> None:
+    def _on_install(self, event: ops.InstallEvent) -> None:
         """Install event handler."""
         if not self.state:
-            return
+            event.defer()
         # This is the default user password
         default_token = "Bearer wazuh:wazuh"  # nosec
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,6 +104,7 @@ class WazuhServerCharm(CharmBaseWithState):
             return
         if not self.state:
             return
+        self.unit.status = ops.MaintenanceStatus()
         wazuh.install_certificates(
             container=self.unit.containers.get("wazuh-server"),
             private_key=self.certificates.private_key,

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,13 +58,14 @@ class WazuhServerCharm(CharmBaseWithState):
         """Install event handler."""
         if not self.state:
             event.defer()
+            return
         # This is the default user password
         default_token = "Bearer wazuh:wazuh"  # nosec
         # The certificates might be self signed and there's no security hardening in
         # passing them to the request since tampering with `localhost` would mean the
         # container filesystem is compromised
         try:
-            r = requests.put(
+            r = requests.put(  # nosec
                 "https://localhost:55000/security/users/2",
                 headers={"Authorization": default_token},
                 data={"password": secrets.token_hex()},
@@ -72,7 +73,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 verify=False,
             )
             r.raise_for_status()
-            r = requests.put(
+            r = requests.put(  # nosec
                 "https://localhost:55000/security/users/1",
                 headers={"Authorization": default_token},
                 data={"password": self.state.api_password},

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,8 +133,15 @@ class WazuhServerCharm(CharmBaseWithState):
         )
         container.add_layer("wazuh", self._pebble_layer, combine=True)
         container.replan()
-        wazuh.change_api_password("wazuh", "wazuh", self.state.api_password)
-        wazuh.change_api_password("wazuh-wui", "wazuh-wui", self.state.api_password)
+        # If the default password has already been changed, we do nothing.
+        try:
+            wazuh.change_api_password("wazuh", "wazuh", self.state.api_password)
+        except wazuh.WazuhAuthenticationError:
+            pass
+        try:
+            wazuh.change_api_password("wazuh-wui", "wazuh-wui", self.state.api_password)
+        except wazuh.WazuhAuthenticationError:
+            pass
         self.unit.status = ops.ActiveStatus()
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -180,11 +180,6 @@ class WazuhServerCharm(CharmBaseWithState):
                     "level": "alive",
                     "tcp": {"port": 55000},
                 },
-                "wazuh-ready": {
-                    "override": "replace",
-                    "level": "alive",
-                    "http": {"url": "https://localhost:55000/cluster/healthcheck"},
-                },
             },
         }
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,7 +133,8 @@ class WazuhServerCharm(CharmBaseWithState):
         )
         container.add_layer("wazuh", self._pebble_layer, combine=True)
         container.replan()
-        wazuh.change_api_password("wazuh", self.state.api_password)
+        wazuh.change_api_password("wazuh", "wazuh", self.state.api_password)
+        wazuh.change_api_password("wazuh-wui", "wazuh-wui", self.state.api_password)
         self.unit.status = ops.ActiveStatus()
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -174,6 +174,18 @@ class WazuhServerCharm(CharmBaseWithState):
                     "startup": "enabled",
                 },
             },
+            "checks": {
+                "wazuh-alive": {
+                    "override": "replace",
+                    "level": "alive",
+                    "tcp": {"port": 55000},
+                },
+                "wazuh-ready": {
+                    "override": "replace",
+                    "level": "alive",
+                    "http": {"url": "https://localhost:55000/cluster/healthcheck"},
+                },
+            },
         }
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,8 +79,6 @@ class WazuhServerCharm(CharmBaseWithState):
             opensearch_relation_data = (
                 opensearch_relation.data[opensearch_relation.app] if opensearch_relation else {}
             )
-            if not opensearch_relation_data:
-                raise RecoverableStateError("No indexer relation data yet.")
             certificates = self.certificates.certificates.get_provider_certificates()
             return State.from_charm(
                 self, opensearch_relation_data, certificates, self.certificates.csr.decode("utf-8")

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,9 @@ class WazuhServerCharm(CharmBaseWithState):
             event.defer()
         # This is the default user password
         default_token = "Bearer wazuh:wazuh"  # nosec
+        # The certificates might be self signed and there's no security hardening in
+        # passing them to the request since tampering with `localhost` would mean the
+        # container filesystem is compromised
         try:
             r = requests.put(
                 "https://localhost:55000/security/users/2",

--- a/src/charm.py
+++ b/src/charm.py
@@ -178,6 +178,11 @@ class WazuhServerCharm(CharmBaseWithState):
                     "level": "alive",
                     "tcp": {"port": 55000},
                 },
+                "filebeat-alive": {
+                    "override": "replace",
+                    "level": "alive",
+                    "exec": {"command": "filebeat test output"},
+                },
             },
         }
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,6 +79,8 @@ class WazuhServerCharm(CharmBaseWithState):
             opensearch_relation_data = (
                 opensearch_relation.data[opensearch_relation.app] if opensearch_relation else {}
             )
+            if not opensearch_relation_data:
+                raise RecoverableStateError("No indexer relation data yet.")
             certificates = self.certificates.certificates.get_provider_certificates()
             return State.from_charm(
                 self, opensearch_relation_data, certificates, self.certificates.csr.decode("utf-8")

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,6 +10,7 @@ import typing
 
 import ops
 import requests
+import secrets
 from ops import pebble
 
 import certificates_observer
@@ -63,7 +64,7 @@ class WazuhServerCharm(CharmBaseWithState):
             r = requests.put(
                 "https://localhost:55000/security/users/2",
                 headers={"Authorization": default_token},
-                data={"password": self.state.api_password},
+                data={"password": secrets.token_hex()},
                 timeout=10,
                 verify=False,
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,11 +6,11 @@
 """Wazuh server charm."""
 
 import logging
+import secrets
 import typing
 
 import ops
 import requests
-import secrets
 from ops import pebble
 
 import certificates_observer

--- a/src/state.py
+++ b/src/state.py
@@ -307,29 +307,36 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
         valid_config = None
         try:
             valid_config = WazuhConfig(**args)  # type: ignore
-            custom_config_ssh_key = _fetch_ssh_repository_key(charm.model, valid_config)
-            agent_password = _fetch_password(charm.model, valid_config.agent_password)
-            api_password = _fetch_password(charm.model, valid_config.api_password)
-            cluster_key = _fetch_cluster_key(charm.model)
-            if not api_password:
-                raise RecoverableStateError("API password is empty.")
-            matching_certificates = _fetch_matching_certificates(
-                provider_certificates, certitificate_signing_request
+        except ValidationError as exc:
+            error_fields = set(
+                itertools.chain.from_iterable(error["loc"] for error in exc.errors())
             )
-            if not matching_certificates:
-                raise InvalidStateError("Certificate is empty.")
-            return cls(
-                agent_password=agent_password,
-                api_password=api_password,
-                cluster_key=cluster_key,
-                indexer_ips=endpoints,
-                filebeat_username=filebeat_username,
-                filebeat_password=filebeat_password,
-                certificate=matching_certificates[0].certificate,
-                root_ca=matching_certificates[0].ca,
-                wazuh_config=valid_config,
-                custom_config_ssh_key=custom_config_ssh_key,
-            )
+            error_field_str = " ".join(f"{f}" for f in error_fields)
+            raise RecoverableStateError(f"Invalid charm configuration {error_field_str}") from exc
+        custom_config_ssh_key = _fetch_ssh_repository_key(charm.model, valid_config)
+        agent_password = _fetch_password(charm.model, valid_config.agent_password)
+        api_password = _fetch_password(charm.model, valid_config.api_password)
+        cluster_key = _fetch_cluster_key(charm.model)
+        if not api_password:
+            raise RecoverableStateError("API password is empty.")
+        matching_certificates = _fetch_matching_certificates(
+            provider_certificates, certitificate_signing_request
+        )
+        try:
+            if matching_certificates:
+                return cls(
+                    agent_password=agent_password,
+                    api_password=api_password,
+                    cluster_key=cluster_key,
+                    indexer_ips=endpoints,
+                    filebeat_username=filebeat_username,
+                    filebeat_password=filebeat_password,
+                    certificate=matching_certificates[0].certificate,
+                    root_ca=matching_certificates[0].ca,
+                    wazuh_config=valid_config,
+                    custom_config_ssh_key=custom_config_ssh_key,
+                )
+            raise RecoverableStateError("Certificate is empty.")
         except ValidationError as exc:
             error_fields = set(
                 itertools.chain.from_iterable(error["loc"] for error in exc.errors())

--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -18,7 +18,6 @@ RELATION_NAME = "ingress"
 PORTS: dict[str, int] = {
     "conn_tcp": 1514,
     "enrole_tcp": 1515,
-    "api_tcp": 55000,
 }
 
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -395,7 +395,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         response.raise_for_status()
         user_id = [
             user["id"]
-            for user in r.json()["data"]["affected_items"]
+            for user in response.json()["data"]["affected_items"]
             if user["username"] == username
         ][0]
         response = requests.put(  # nosec

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -398,4 +398,6 @@ def change_api_password(old_password: str, new_password: str) -> None:
         r.raise_for_status()
     except requests.exceptions.RequestException as exc:
         logger.error("Error modifying the default password: %s", exc)
+        logger.error("OLD: %s", old_password)
+        logger.error("NEW: %s", new_password)
         raise WazuhInstallationError("Error modifying the default password.") from exc

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -382,9 +382,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
             return
         response.raise_for_status()
         token = response.json()["data"]["token"]
-        headers = {
-            "Authorization": f"Bearer {token}"
-        }
+        headers = {"Authorization": f"Bearer {token}"}
         response = requests.get(  # nosec
             "https://localhost:55000/security/users",
             headers=headers,

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -380,14 +380,14 @@ def change_api_password(old_password: str, new_password: str) -> None:
         # The new password already matches. Nothing to do.
         if r.status_code == 200:
             return
-        r = requests.put(  # nosec
-            "https://localhost:55000/security/users/2",
-            auth=("wazuh", old_password),
-            data={"password": secrets.token_hex()},
-            timeout=10,
-            verify=False,
-        )
-        r.raise_for_status()
+        # r = requests.put(  # nosec
+        #     "https://localhost:55000/security/users/2",
+        #     auth=("wazuh", old_password),
+        #     data={"password": secrets.token_hex()},
+        #     timeout=10,
+        #     verify=False,
+        # )
+        # r.raise_for_status()
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/1",
             auth=("wazuh", old_password),

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -385,14 +385,14 @@ def change_api_password(old_password: str, new_password: str) -> None:
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
-        r = requests.put(  # nosec
-            "https://localhost:55000/security/users/2",
-            headers=headers,
-            data={"password": secrets.token_hex()},
-            timeout=10,
-            verify=False,
-        )
-        r.raise_for_status()
+        # r = requests.put(  # nosec
+        #     "https://localhost:55000/security/users/2",
+        #     headers=headers,
+        #     data={"password": secrets.token_hex()},
+        #     timeout=10,
+        #     verify=False,
+        # )
+        # r.raise_for_status()
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/1",
             headers=headers,

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -377,10 +377,10 @@ def change_api_password(old_password: str, new_password: str) -> None:
             timeout=10,
             verify=False,
         )
-        token = r.json()["data"]["token"]
         # The old password has already been changed. Nothing to do.
         if r.status_code == 401:
             return
+        token = r.json()["data"]["token"]
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/2",
             headers={"Authorization": f"Bearer {token}"},

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -37,6 +37,10 @@ class WazuhInstallationError(Exception):
     """Base exception for Wazuh errors."""
 
 
+class WazuhAuthenticationError(Exception):
+    """Wazuh authentication errors."""
+
+
 class NodeType(Enum):
     """Enum for the Wazuh node types.
 
@@ -365,6 +369,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         new_password: the new API password for the user.
 
     Raises:
+        WazuhAuthenticationError: if an authentication error occurs.
         WazuhInstallationError: if an error occurs while processing the requests.
     """
     # The certificates might be self signed and there's no security hardening in
@@ -379,7 +384,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         )
         # The old password has already been changed. Nothing to do.
         if response.status_code == 401:
-            return
+            raise WazuhAuthenticationError("The provided password is not valid.")
         response.raise_for_status()
         token = response.json()["data"]["token"] if response.json()["data"] else None
         headers = {"Authorization": f"Bearer {token}"}

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -381,9 +381,13 @@ def change_api_password(old_password: str, new_password: str) -> None:
         if r.status_code == 401:
             return
         token = r.json()["data"]["token"]
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/2",
-            headers={"Authorization": f"Bearer {token}"},
+            headers=headers,
             data={"password": secrets.token_hex()},
             timeout=10,
             verify=False,
@@ -391,7 +395,7 @@ def change_api_password(old_password: str, new_password: str) -> None:
         r.raise_for_status()
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/1",
-            headers={"Authorization": f"Bearer {token}"},
+            headers=headers,
             data={"password": new_password},
             timeout=10,
             verify=False,

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -21,8 +21,6 @@ import yaml
 # https://github.com/PyCQA/bandit/issues/767
 from lxml import etree  # nosec
 
-import state
-
 AGENT_PASSWORD_PATH = Path("/var/ossec/etc/authd.pass")
 CERTIFICATES_PATH = Path("/etc/filebeat/certs")
 FILEBEAT_CONF_PATH = Path("/etc/filebeat/filebeat.yml")

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -371,7 +371,7 @@ def change_api_password(old_password: str, new_password: str) -> None:
     # passing them to the request since tampering with `localhost` would mean the
     # container filesystem is compromised
     try:
-        r = requests.put(  # nosec
+        r = requests.get(  # nosec
             "https://localhost:55000/security/user/authenticate",
             auth=("wazuh", new_password),
             timeout=10,
@@ -400,4 +400,14 @@ def change_api_password(old_password: str, new_password: str) -> None:
         logger.error("Error modifying the default password: %s", exc)
         logger.error("OLD: %s", old_password)
         logger.error("NEW: %s", new_password)
+        try:
+            r = requests.get(  # nosec
+                "https://localhost:55000/security/user/authenticate",
+                auth=("wazuh", old_password),
+                timeout=10,
+                verify=False,
+            )
+            r.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            logger.error("Error modifying the default password: %s", exc)
         raise WazuhInstallationError("Error modifying the default password.") from exc

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -381,7 +381,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         if response.status_code == 401:
             return
         response.raise_for_status()
-        token = response.json()["data"]["token"]
+        token = response.json()["data"]["token"] if response.json()["data"] else None
         headers = {"Authorization": f"Bearer {token}"}
         response = requests.get(  # nosec
             "https://localhost:55000/security/users",
@@ -390,10 +390,9 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
             verify=False,
         )
         response.raise_for_status()
+        data = response.json()["data"]
         user_id = [
-            user["id"]
-            for user in response.json()["data"]["affected_items"]
-            if user["username"] == username
+            user["id"] for user in data["affected_items"] if data and user["username"] == username
         ][0]
         response = requests.put(  # nosec
             f"https://localhost:55000/security/users/{user_id}",

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -382,14 +382,14 @@ def change_api_password(old_password: str, new_password: str) -> None:
         # The new password already matches. Nothing to do.
         if r.status_code == 204:
             return
-        r = requests.put(  # nosec
-            "https://localhost:55000/security/users/2",
-            headers={"Authorization": token},
-            data={"password": secrets.token_hex()},
-            timeout=10,
-            verify=False,
-        )
-        r.raise_for_status()
+        # r = requests.put(  # nosec
+        #     "https://localhost:55000/security/users/2",
+        #     headers={"Authorization": token},
+        #     data={"password": secrets.token_hex()},
+        #     timeout=10,
+        #     verify=False,
+        # )
+        # r.raise_for_status()
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/1",
             headers={"Authorization": token},

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -409,4 +409,5 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         logger.error("Error modifying the default password: %s", exc)
+        logger.error("Error %s", response.json())
         raise WazuhInstallationError("Error modifying the default password.") from exc

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -383,8 +383,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         response.raise_for_status()
         token = response.json()["data"]["token"]
         headers = {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}"
         }
         response = requests.get(  # nosec
             "https://localhost:55000/security/users",
@@ -401,7 +400,7 @@ def change_api_password(username: str, old_password: str, new_password: str) -> 
         response = requests.put(  # nosec
             f"https://localhost:55000/security/users/{user_id}",
             headers=headers,
-            data={"password": new_password},
+            json={"password": new_password},
             timeout=10,
             verify=False,
         )

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -378,7 +378,7 @@ def change_api_password(old_password: str, new_password: str) -> None:
             verify=False,
         )
         # The new password already matches. Nothing to do.
-        if r.status_code == 204:
+        if r.status_code == 200:
             return
         r = requests.put(  # nosec
             "https://localhost:55000/security/users/2",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,6 @@ async def application_fixture(
     )
     await model.integrate(traefik.name, application.name)
     await model.wait_for_idle(
-        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=2000
+        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=1500
     )
     yield application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,6 @@ async def application_fixture(
     )
     await model.integrate(traefik.name, application.name)
     await model.wait_for_idle(
-        apps=[application.name, traefik.name], status="active", raise_on_error=True
+        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=1200
     )
     yield application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,6 @@ async def application_fixture(
     )
     await model.integrate(traefik.name, application.name)
     await model.wait_for_idle(
-        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=2400
+        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=2000
     )
     yield application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@
 import logging
 import os.path
 import secrets
+import string
 import typing
 
 import pytest
@@ -116,7 +117,8 @@ async def charm_fixture(pytestconfig: pytest.Config) -> str:
 @pytest.fixture(scope="module", name="api_password")
 def api_password_fixture() -> str:
     """Get Wazuh's API password for the 'wazuh' user."""
-    return secrets.token_hex()
+    alphabet = string.ascii_letters + string.digits + string.punctuation
+    return "".join(secrets.choice(alphabet) for _ in range(16))
 
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,6 @@ async def application_fixture(
     )
     await model.integrate(traefik.name, application.name)
     await model.wait_for_idle(
-        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=2000
+        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=2400
     )
     yield application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -136,11 +136,11 @@ async def application_fixture(
         "wazuh-server-image": pytestconfig.getoption("--wazuh-server-image"),
     }
     secret_id = await model.add_secret(name="api-password", data_args=[f"value={api_password}"])
-    # Wazuh mistakenly thinks this is a password
-    await model.grant_secret(secret_name="api-password", application="wazuh-server")  # nosec
     application = await model.deploy(
         f"./{charm}", resources=resources, config={"api-password": secret_id}, trust=True
     )
+    # Wazuh mistakenly thinks this is a password
+    await model.grant_secret(secret_name="api-password", application="wazuh-server")  # nosec
     await model.integrate(
         f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
         application.name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -141,14 +141,11 @@ async def application_fixture(
         "wazuh-server-image": pytestconfig.getoption("--wazuh-server-image"),
     }
     await model.add_secret(
-        name=state.WAZUH_CLUSTER_KEY_SECRET_LABEL,
+        name=state.WAZUH_API_CREDENTIALS,
         data_args=[f"{username}={password}" for username, password in api_credentials.items()],
     )
     application = await model.deploy(f"./{charm}", resources=resources, trust=True)
-    # Wazuh mistakenly thinks this is a password
-    await model.grant_secret(
-        secret_name="wazuh-api-credentials", application=application.name
-    )  # nosec
+    await model.grant_secret(secret_name=state.WAZUH_API_CREDENTIALS, application=application.name)
     await model.integrate(
         f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
         application.name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -140,7 +140,7 @@ async def application_fixture(
         f"./{charm}", resources=resources, config={"api-password": secret_id}, trust=True
     )
     # Wazuh mistakenly thinks this is a password
-    await model.grant_secret(secret_name="api-password", application="wazuh-server")  # nosec
+    await model.grant_secret(secret_name="api-password", application=application.name)  # nosec
     await model.integrate(
         f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
         application.name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,7 @@ async def opensearch_provider_fixture(
     await machine_model.integrate(self_signed_certificates.name, application.name)
     await machine_model.create_offer(f"{application.name}:opensearch-client", application.name)
     await machine_model.wait_for_idle(
-        apps=[application.name, self_signed_certificates.name], status="active", timeout=1400
+        apps=[application.name, self_signed_certificates.name], status="active", timeout=2000
     )
     yield application
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,6 @@ async def application_fixture(
     )
     await model.integrate(traefik.name, application.name)
     await model.wait_for_idle(
-        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=1200
+        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=1500
     )
     yield application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -146,7 +146,9 @@ async def application_fixture(
     )
     application = await model.deploy(f"./{charm}", resources=resources, trust=True)
     # Wazuh mistakenly thinks this is a password
-    await model.grant_secret(secret_name="api-password", application=application.name)  # nosec
+    await model.grant_secret(
+        secret_name="wazuh-api-credentials", application=application.name
+    )  # nosec
     await model.integrate(
         f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
         application.name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,8 @@ from juju.application import Application
 from juju.model import Controller, Model
 from pytest_operator.plugin import OpsTest
 
+import state
+
 logger = logging.getLogger(__name__)
 
 MACHINE_MODEL_CONFIG = {
@@ -114,11 +116,12 @@ async def charm_fixture(pytestconfig: pytest.Config) -> str:
     return charm
 
 
-@pytest.fixture(scope="module", name="api_password")
-def api_password_fixture() -> str:
-    """Get Wazuh's API password for the 'wazuh' user."""
+@pytest.fixture(scope="module", name="api_credentials")
+def api_credentials_fixture() -> dict[str, str]:
+    """Get Wazuh's API credentials."""
     alphabet = string.ascii_letters + string.digits + string.punctuation
-    return "".join(secrets.choice(alphabet) for _ in range(16))
+    password = "".join(secrets.choice(alphabet) for _ in range(16))
+    return {"wazuh": password, "wazuh-wui": password}
 
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments
@@ -130,17 +133,18 @@ async def application_fixture(
     opensearch_provider: Application,
     pytestconfig: pytest.Config,
     traefik: Application,
-    api_password: str,
+    api_credentials: dict[str, str],
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy the charm."""
     # Deploy the charm and wait for active/idle status
     resources = {
         "wazuh-server-image": pytestconfig.getoption("--wazuh-server-image"),
     }
-    secret_id = await model.add_secret(name="api-password", data_args=[f"value={api_password}"])
-    application = await model.deploy(
-        f"./{charm}", resources=resources, config={"api-password": secret_id}, trust=True
+    await model.add_secret(
+        name=state.WAZUH_CLUSTER_KEY_SECRET_LABEL,
+        data_args=[f"{username}={password}" for username, password in api_credentials.items()],
     )
+    application = await model.deploy(f"./{charm}", resources=resources, trust=True)
     # Wazuh mistakenly thinks this is a password
     await model.grant_secret(secret_name="api-password", application=application.name)  # nosec
     await model.integrate(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,7 +113,6 @@ async def charm_fixture(pytestconfig: pytest.Config) -> str:
     return charm
 
 
-# pylint: disable=too-many-arguments, too-many-positional-arguments
 @pytest.fixture(scope="module", name="api_password")
 def api_password_fixture() -> str:
     """Get Wazuh's API password for the 'wazuh' user."""
@@ -137,6 +136,8 @@ async def application_fixture(
         "wazuh-server-image": pytestconfig.getoption("--wazuh-server-image"),
     }
     secret_id = await model.add_secret(name="api-password", data_args=[f"value={api_password}"])
+    # Wazuh mistakenly thinks this is a password
+    await model.grant_secret(secret_name="api-password", application="wazuh-server")  # nosec
     application = await model.deploy(
         f"./{charm}", resources=resources, config={"api-password": secret_id}, trust=True
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,6 @@ async def application_fixture(
     )
     await model.integrate(traefik.name, application.name)
     await model.wait_for_idle(
-        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=1500
+        apps=[application.name, traefik.name], status="active", raise_on_error=True, timeout=2000
     )
     yield application

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -31,7 +31,7 @@ async def test_api(model: Model, application: Application, api_credentials: dict
     unit = list(status.applications[application.name].units)[0]
     address = status["applications"][application.name]["units"][unit]["address"]
     # The pebble plan is applied again to change the password, so I wait a bit
-    time.sleep(10)
+    time.sleep(5)
     response = requests.post(  # nosec
         f"https://{address}:55000/security/user/authenticate",
         auth=("wazuh", api_credentials["wazuh"]),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -30,8 +30,6 @@ async def test_api(model: Model, application: Application, api_credentials: dict
     status = await model.get_status()
     unit = list(status.applications[application.name].units)[0]
     address = status["applications"][application.name]["units"][unit]["address"]
-    # The pebble plan is applied again to change the password, so I wait a bit
-    time.sleep(5)
     response = requests.post(  # nosec
         f"https://{address}:55000/security/user/authenticate",
         auth=("wazuh", api_credentials["wazuh"]),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -21,22 +21,6 @@ APP_NAME = CHARMCRAFT["name"]
 
 
 @pytest.mark.abort_on_fail
-async def test_filebeat_ok(application: Application):
-    """Deploy the charm together with related charms.
-
-    Assert: the filebeat config is valid.
-    """
-    wazuh_unit = application.units[0]  # type: ignore
-    pebble_exec = "PEBBLE_SOCKET=/charm/containers/wazuh-server/pebble.socket pebble exec"
-    action = await wazuh_unit.run(f"{pebble_exec} -- /usr/bin/filebeat test output", timeout=10)
-    await action.wait()
-    code = action.results.get("return-code")
-    stdout = action.results.get("stdout")
-    stderr = action.results.get("stderr")
-    assert code == 0, f"filebeat test failed with code {code}: {stderr or stdout}"
-
-
-@pytest.mark.abort_on_fail
 async def test_api(model: Model, application: Application, api_password: str):
     """Deploy the charm together with related charms.
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,7 +6,6 @@
 """Integration tests."""
 
 import logging
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 
 import pytest
+import requests
 import yaml
 from juju.application import Application
 from juju.model import Model
@@ -20,15 +21,11 @@ APP_NAME = CHARMCRAFT["name"]
 
 
 @pytest.mark.abort_on_fail
-async def test_filebeat_ok(model: Model, application: Application):
+async def test_filebeat_ok(application: Application):
     """Deploy the charm together with related charms.
 
     Assert: the filebeat config is valid.
     """
-    model.wait_for_idle(
-        apps=[application.name], status="active", raise_on_blocked=True, timeout=1000
-    )
-
     wazuh_unit = application.units[0]  # type: ignore
     output = await wazuh_unit.run("filebeat test output", timeout=10)
     code = output.data["results"].get("Code")
@@ -38,14 +35,30 @@ async def test_filebeat_ok(model: Model, application: Application):
 
 
 @pytest.mark.abort_on_fail
+async def test_api(model: Model, application: Application, api_password: str):
+    """Deploy the charm together with related charms.
+
+    Assert: the filebeat config is valid.
+    """
+    status = await model.get_status()
+    unit = list(status.applications[application.name].units)[0]
+    address = status["applications"][application.name]["units"][unit]["address"]
+    auth = f"Bearer wazuh:{api_password}"
+    response = requests.post(  # nosec
+        f"https://{address}:55000/security/user/authenticate",
+        headers={"Authorization": auth},
+        timeout=10,
+        verify=False,
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.abort_on_fail
 async def test_clustering_ok(model: Model, application: Application):
     """Deploy the charm together with related charms and scale to two units.
 
     Assert: the clustering config is valid.
     """
-    model.wait_for_idle(
-        apps=[application.name], status="active", raise_on_blocked=True, timeout=1000
-    )
     await application.scale(2)
     await model.wait_for_idle(idle_period=30, apps=[application.name], status="active")
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,10 +29,9 @@ async def test_api(model: Model, application: Application, api_password: str):
     status = await model.get_status()
     unit = list(status.applications[application.name].units)[0]
     address = status["applications"][application.name]["units"][unit]["address"]
-    auth = f"Bearer wazuh:{api_password}"
     response = requests.post(  # nosec
         f"https://{address}:55000/security/user/authenticate",
-        headers={"Authorization": auth},
+        auth=("wazuh", api_password),
         timeout=10,
         verify=False,
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,6 +6,7 @@
 """Integration tests."""
 
 import logging
+import time
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,8 @@ async def test_api(model: Model, application: Application, api_credentials: dict
     status = await model.get_status()
     unit = list(status.applications[application.name].units)[0]
     address = status["applications"][application.name]["units"][unit]["address"]
+    # The pebble plan is applied again to change the password, so I wait a bit
+    time.sleep(10)
     response = requests.post(  # nosec
         f"https://{address}:55000/security/user/authenticate",
         auth=("wazuh", api_credentials["wazuh"]),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -44,11 +44,10 @@ async def test_clustering_ok(model: Model, application: Application):
 
     Assert: the clustering config is valid.
     """
+    await application.scale(2)
     await model.wait_for_idle(
         apps=[application.name], status="active", raise_on_blocked=True, timeout=1000
     )
-    await application.scale(2)
-    await model.wait_for_idle(idle_period=30, apps=[application.name], status="active")
 
     wazuh_unit = application.units[0]  # type: ignore
     pebble_exec = "PEBBLE_SOCKET=/charm/containers/wazuh-server/pebble.socket pebble exec"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -21,7 +21,7 @@ APP_NAME = CHARMCRAFT["name"]
 
 
 @pytest.mark.abort_on_fail
-async def test_api(model: Model, application: Application, api_password: str):
+async def test_api(model: Model, application: Application, api_credentials: dict[str, str]):
     """Deploy the charm together with related charms.
 
     Assert: the filebeat config is valid.
@@ -31,7 +31,7 @@ async def test_api(model: Model, application: Application, api_password: str):
     address = status["applications"][application.name]["units"][unit]["address"]
     response = requests.post(  # nosec
         f"https://{address}:55000/security/user/authenticate",
-        auth=("wazuh", api_password),
+        auth=("wazuh", api_credentials["wazuh"]),
         timeout=10,
         verify=False,
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -119,7 +119,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         container=container, password=agent_password
     )
     pull_configuration_files_mock.assert_called_with(container)
-    change_api_password_mock.assert_called_with("wazuh", api_password)
+    change_api_password_mock.assert_any_call("wazuh", "wazuh", api_password)
+    change_api_password_mock.assert_any_call("wazuh-wui", "wazuh-wui", api_password)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 
@@ -186,7 +187,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server/0",
         cluster_key,
     )
-    change_api_password_mock.assert_called_with("wazuh", api_password)
+    change_api_password_mock.assert_any_call("wazuh", "wazuh", api_password)
+    change_api_password_mock.assert_any_call("wazuh-wui", "wazuh-wui", api_password)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,7 +54,9 @@ def test_invalid_state_reaches_blocked_status(state_from_charm_mock):
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
+@patch.object(wazuh, "change_api_password")
 def test_reconcile_reaches_active_status_when_repository_and_password_configured(
+    change_api_password_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -117,6 +119,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         container=container, password=agent_password
     )
     pull_configuration_files_mock.assert_called_with(container)
+    change_api_password_mock.assert_called_with("wazuh", api_password)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 
@@ -128,7 +131,9 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
+@patch.object(wazuh, "change_api_password")
 def test_reconcile_reaches_active_status_when_repository_and_password_not_configured(
+    change_api_password_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -181,6 +186,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server/0",
         cluster_key,
     )
+    change_api_password_mock.assert_called_with("wazuh", api_password)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,9 +54,7 @@ def test_invalid_state_reaches_blocked_status(state_from_charm_mock):
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
-@patch.object(wazuh, "change_api_password")
 def test_reconcile_reaches_active_status_when_repository_and_password_configured(
-    change_api_password_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -122,10 +120,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         container=container, password=agent_password
     )
     pull_configuration_files_mock.assert_called_with(container)
-    change_api_password_mock.assert_any_call("wazuh", "wazuh", api_credentials["wazuh"])
-    change_api_password_mock.assert_any_call(
-        "wazuh-wui", "wazuh-wui", api_credentials["wazuh-wui"]
-    )
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 
@@ -137,9 +131,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
-@patch.object(wazuh, "change_api_password")
 def test_reconcile_reaches_active_status_when_repository_and_password_not_configured(
-    change_api_password_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -196,10 +188,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         ["wazuh-server-0.wazuh-server-endpoints"],
         "wazuh-server/0",
         cluster_key,
-    )
-    change_api_password_mock.assert_any_call("wazuh", "wazuh", api_credentials["wazuh"])
-    change_api_password_mock.assert_any_call(
-        "wazuh-wui", "wazuh-wui", api_credentials["wazuh-wui"]
     )
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -53,12 +53,14 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
     """
     custom_config_repository = "git+ssh://user1@git.server/repo_name@main"
     secret_id = f"secret:{secrets.token_hex(21)}"
+    api_password = secrets.token_hex()
     wazuh_config = WazuhConfig(
-        custom_config_repository=custom_config_repository, custom_config_ssh_key=secret_id
+        api_password=api_password,
+        custom_config_repository=custom_config_repository,
+        custom_config_ssh_key=secret_id,
     )
     password = secrets.token_hex()
     agent_password = secrets.token_hex()
-    api_password = secrets.token_hex()
     state_from_charm_mock.return_value = State(
         agent_password=agent_password,
         api_password=api_password,
@@ -125,7 +127,9 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         indexer_ips=["10.0.0.1"],
         filebeat_username="user1",
         filebeat_password=password,
-        wazuh_config=WazuhConfig(custom_config_repository=None, custom_config_ssh_key=None),
+        wazuh_config=WazuhConfig(
+            api_password=api_password, custom_config_repository=None, custom_config_ssh_key=None
+        ),
         custom_config_ssh_key=None,
     )
     harness = Harness(WazuhServerCharm)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -30,7 +30,7 @@ def test_state_invalid_relation_data(opensearch_relation_data):
     """
     mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
     secret_id = f"secret:{secrets.token_hex()}"
-    mock_charm.config = {"api-password": secret_id}
+    mock_charm.config = {"wazuh-api-credentials": secret_id}
     provider_certificates = [
         certificates.ProviderCertificate(
             relation_id="certificates-provider/1",
@@ -58,7 +58,7 @@ def test_state_without_proxy():
     """
     mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
     secret_id = f"secret:{secrets.token_hex()}"
-    mock_charm.config = {"api-password": secret_id}
+    mock_charm.config = {"wazuh-api-credentials": secret_id}
     endpoints = ["10.0.0.1", "10.0.0.2"]
     username = "user1"
     password = secrets.token_hex()
@@ -113,7 +113,7 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
     """
     mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
     secret_id = f"secret:{secrets.token_hex()}"
-    mock_charm.config = {"api-password": secret_id}
+    mock_charm.config = {"wazuh-api-credentials": secret_id}
     endpoints = ["10.0.0.1", "10.0.0.2"]
     username = "user1"
     password = secrets.token_hex()
@@ -172,7 +172,7 @@ def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "INVALID_URL")
     mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
     secret_id = f"secret:{secrets.token_hex()}"
-    mock_charm.config = {"api-password": secret_id}
+    mock_charm.config = {"wazuh-api-credentials": secret_id}
 
     endpoints = ["10.0.0.1", "10.0.0.2"]
     username = "user1"
@@ -221,7 +221,7 @@ def test_state_when_repository_secret_not_found(monkeypatch: pytest.MonkeyPatch)
         mock_charm,
         "config",
         {
-            "api-password": secret_id,
+            "wazuh-api-credentials": secret_id,
             "custom-config-repository": "git+ssh://user1@git.server/repo_name@main",
             "custom-config-ssh-key": repository_secret_id,
         },
@@ -268,7 +268,7 @@ def test_state_when_agent_password_secret_not_found(monkeypatch: pytest.MonkeyPa
         "config",
         {
             "agent-password": secret_id,
-            "api-password": secret_id,
+            "wazuh-api-credentials": secret_id,
         },
     )
 
@@ -314,7 +314,7 @@ def test_state_when_repository_secret_invalid(monkeypatch: pytest.MonkeyPatch):
         mock_charm,
         "config",
         {
-            "api-password": secret_id,
+            "wazuh-api-credentials": secret_id,
             "custom-config-repository": "git+ssh://user1@git.server/repo_name@main",
             "custom-config-ssh-key": repository_secret_id,
         },
@@ -362,7 +362,7 @@ def test_state_when_agent_secret_invalid(monkeypatch: pytest.MonkeyPatch):
         "config",
         {
             "agent-password": secret_id,
-            "api-password": secret_id,
+            "wazuh-api-credentials": secret_id,
         },
     )
 
@@ -410,7 +410,7 @@ def test_state_when_repository_secret_valid(monkeypatch: pytest.MonkeyPatch):
         mock_charm,
         "config",
         {
-            "api-password": value,
+            "wazuh-api-credentials": value,
             "custom-config-repository": custom_config_repository,
             "custom-config-ssh-key": repository_secret_id,
         },
@@ -472,7 +472,7 @@ def test_state_when_agent_password_secret_valid(monkeypatch: pytest.MonkeyPatch)
         "config",
         {
             "agent-password": secret_id,
-            "api-password": secret_id,
+            "wazuh-api-credentials": secret_id,
         },
     )
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -102,6 +102,7 @@ def test_state_without_proxy():
     assert charm_state.proxy.http_proxy is None
     assert charm_state.proxy.https_proxy is None
     assert charm_state.proxy.no_proxy is None
+    assert not charm_state.is_default_api_password
 
 
 def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
@@ -159,6 +160,7 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
     assert str(charm_state.proxy.http_proxy) == "http://squid.proxy:3228/"
     assert str(charm_state.proxy.https_proxy) == "https://squid.proxy:3228/"
     assert charm_state.proxy.no_proxy == "localhost"
+    assert not charm_state.is_default_api_password
 
 
 def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -89,7 +89,8 @@ def test_state_without_proxy():
         mock_charm, opensearch_relation_data, provider_certificates, csr
     )
 
-    assert charm_state.api_password == value
+    assert charm_state.api_credentials is not None
+    assert charm_state.api_credentials["value"] == value
     assert charm_state.cluster_key == value
     assert charm_state.indexer_ips == endpoints
     assert charm_state.filebeat_username == username
@@ -145,7 +146,8 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
     charm_state = state.State.from_charm(
         mock_charm, opensearch_relation_data, provider_certificates, csr
     )
-    assert charm_state.api_password == value
+    assert charm_state.api_credentials is not None
+    assert charm_state.api_credentials["value"] == value
     assert charm_state.cluster_key == value
     assert charm_state.indexer_ips == endpoints
     assert charm_state.certificate == certificate

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -66,11 +66,6 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                         "service": "juju-testing-observer-charm-service-enrole-tcp",
                         "rule": "ClientIP(`0.0.0.0/0`)",
                     },
-                    "juju-testing-observer-charm-api-tcp": {
-                        "entryPoints": ["api-tcp"],
-                        "service": "juju-testing-observer-charm-service-api-tcp",
-                        "rule": "ClientIP(`0.0.0.0/0`)",
-                    },
                 },
                 "services": {
                     "juju-testing-observer-charm-service-conn-tcp": {
@@ -79,9 +74,6 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     "juju-testing-observer-charm-service-enrole-tcp": {
                         "loadBalancer": {"servers": [{"address": "wazuh-server.local:1515"}]}
                     },
-                    "juju-testing-observer-charm-service-api-tcp": {
-                        "loadBalancer": {"servers": [{"address": "wazuh-server.local:55000"}]}
-                    },
                 },
             },
         },
@@ -89,7 +81,6 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
             "entryPoints": {
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
-                "api-tcp": {"address": ":55000"},
             }
         },
     )

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -322,3 +322,15 @@ def test_configure_git_when_no_key_no_repository_specified() -> None:
     wazuh.configure_git(container, None, None)
     assert not container.exists(wazuh.KNOWN_HOSTS_PATH)
     assert not container.exists(wazuh.RSA_PATH)
+
+
+def test_generate_api_credentials() -> None:
+    """
+    arrange: do nothing.
+    act: generate API credentials.
+    assert: a map with the 'wazuh' and 'wazuh-wui' credentials is returned.
+    """
+    credentials = wazuh.generate_api_credentials()
+
+    assert "wazuh" in credentials
+    assert "wazuh-wui" in credentials

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -4,3 +4,4 @@ scan:
   # Ignore TLS cert installed by Wazuh
   skip-files:
     - /var/ossec/etc/sslmanager.key
+    - /var/ossec/framework/python/lib/python3.10/site-packages/google/auth/crypt/__pycache__/_python_rsa.cpython-310.pyc


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Change default API passwords on install for one defined in the charm configuration
* Do not expose port 55000
* Use Python >= 3.10 type hints

### Rationale

<!-- The reason the change is needed -->
Security hardening

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
