### PR TITLE
Skip certificate verification on LB

### DIFF
--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -62,7 +62,10 @@ class TraefikRouteObserver(Object):
         for protocol, port in PORTS.items():
             sanitized_protocol = protocol.replace("_", "-")
             entry_points[sanitized_protocol] = {"address": f":{port}"}
-        return {"entryPoints": entry_points}
+        return {
+            "entryPoints": entry_points,
+            "tcpServersTransport": {"tls": {"insecureSkipVerify": "true"}},
+        }
 
     @property
     def _ingress_config(self) -> dict[str, dict[str, dict[str, typing.Any]]]:

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -90,7 +90,8 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
                 "api-tcp": {"address": ":55000"},
-            }
+            },
+            "tcpServersTransport": {"tls": {"insecureSkipVerify": "true"}},
         },
     )
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Might be causing the connection termination issues we're currently experienced on our setup

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
