### PR TITLE
Reach blocked status if the certificate has not been issued yet

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -325,7 +325,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
                     wazuh_config=valid_config,
                     custom_config_ssh_key=custom_config_ssh_key,
                 )
-            raise InvalidStateError("Certificate is empty.")
+            raise RecoverableStateError("Certificate is empty.")
         except ValidationError as exc:
             error_fields = set(
                 itertools.chain.from_iterable(error["loc"] for error in exc.errors())

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -44,7 +44,7 @@ def test_state_invalid_relation_data(opensearch_relation_data):
 
     with pytest.raises(state.InvalidStateError):
         state.State.from_charm(mock_charm, opensearch_relation_data, provider_certificates, "1")
-    with pytest.raises(state.InvalidStateError):
+    with pytest.raises(state.RecoverableStateError):
         state.State.from_charm(mock_charm, opensearch_relation_data, [], "1")
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Reach blocked status if the certificate has not been issued yet.

### Rationale

<!-- The reason the change is needed -->
Fixes an issue causing the install hook to fail on clean installation

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
