### PR TITLE
Change traefiks rule matcher to match by SNI

### DIFF
--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -84,7 +84,7 @@ class TraefikRouteObserver(Object):
             routers[f"juju-{self.model.name}-{self.model.app.name}-{sanitized_protocol}"] = {
                 "entryPoints": [sanitized_protocol],
                 "service": service_name,
-                "rule": "ClientIP(`0.0.0.0/0`)",
+                "rule": "HostSNI(`*`)",
             }
             services[service_name] = {
                 "loadBalancer": {"servers": [{"address": f"{self.hostname}:{port}"}]}

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -59,17 +59,17 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     "juju-testing-observer-charm-conn-tcp": {
                         "entryPoints": ["conn-tcp"],
                         "service": "juju-testing-observer-charm-service-conn-tcp",
-                        "rule": "ClientIP(`0.0.0.0/0`)",
+                        "rule": "HostSNI(`*`)",
                     },
                     "juju-testing-observer-charm-enrole-tcp": {
                         "entryPoints": ["enrole-tcp"],
                         "service": "juju-testing-observer-charm-service-enrole-tcp",
-                        "rule": "ClientIP(`0.0.0.0/0`)",
+                        "rule": "HostSNI(`*`)",
                     },
                     "juju-testing-observer-charm-api-tcp": {
                         "entryPoints": ["api-tcp"],
                         "service": "juju-testing-observer-charm-service-api-tcp",
-                        "rule": "ClientIP(`0.0.0.0/0`)",
+                        "rule": "HostSNI(`*`)",
                     },
                 },
                 "services": {


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
See if I got lucky as per https://community.traefik.io/t/tcp-route-not-working/5526/3

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
