### PR TITLE
Increase Traefik's termination delay

### DIFF
--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -86,7 +86,10 @@ class TraefikRouteObserver(Object):
                 "tls": {"passthrough": True},
             }
             services[service_name] = {
-                "loadBalancer": {"servers": [{"address": f"{self.hostname}:{port}"}]}
+                "loadBalancer": {
+                    "servers": [{"address": f"{self.hostname}:{port}"}],
+                    "terminationDelay": 1000,
+                }
             }
         return {
             "tcp": {

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -71,10 +71,16 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                 },
                 "services": {
                     "juju-testing-observer-charm-service-conn-tcp": {
-                        "loadBalancer": {"servers": [{"address": "wazuh-server.local:1514"}]}
+                        "loadBalancer": {
+                            "servers": [{"address": "wazuh-server.local:1514"}],
+                            "terminationDelay": 1000,
+                        }
                     },
                     "juju-testing-observer-charm-service-enrole-tcp": {
-                        "loadBalancer": {"servers": [{"address": "wazuh-server.local:1515"}]}
+                        "loadBalancer": {
+                            "servers": [{"address": "wazuh-server.local:1515"}],
+                            "terminationDelay": 1000,
+                        }
                     },
                 },
             },


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Increase Traefik's termination delay to prevent the connection from being closed when the network is slow

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
