### PR TITLE
Fix Traefik configuration to allow for non TLS connections

### DIFF
--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -82,8 +82,7 @@ class TraefikRouteObserver(Object):
             routers[f"juju-{self.model.name}-{self.model.app.name}-{sanitized_protocol}"] = {
                 "entryPoints": [sanitized_protocol],
                 "service": service_name,
-                "rule": "HostSNI(`*`)",
-                "tls": {"passthrough": True},
+                "rule": "ClientIP(`0.0.0.0/0`)",
             }
             services[service_name] = {
                 "loadBalancer": {"servers": [{"address": f"{self.hostname}:{port}"}]}

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -59,14 +59,12 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     "juju-testing-observer-charm-conn-tcp": {
                         "entryPoints": ["conn-tcp"],
                         "service": "juju-testing-observer-charm-service-conn-tcp",
-                        "rule": "HostSNI(`*`)",
-                        "tls": {"passthrough": True},
+                        "rule": "ClientIP(`0.0.0.0/0`)",
                     },
                     "juju-testing-observer-charm-enrole-tcp": {
                         "entryPoints": ["enrole-tcp"],
                         "service": "juju-testing-observer-charm-service-enrole-tcp",
-                        "rule": "HostSNI(`*`)",
-                        "tls": {"passthrough": True},
+                        "rule": "ClientIP(`0.0.0.0/0`)",
                     },
                 },
                 "services": {


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix Traefik configuration to allow for non TLS connections

### Rationale

<!-- The reason the change is needed -->
Connections from the Wazuh agent to port 1514 are not TLS

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
