### PR TITLE
Set workload version

### DIFF
--- a/src-docs/wazuh.py.md
+++ b/src-docs/wazuh.py.md
@@ -15,7 +15,7 @@ Wazuh operational logic.
 
 ---
 
-<a href="../src/wazuh.py#L115"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L116"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `update_configuration`
 
@@ -50,7 +50,7 @@ Update the workload configuration.
 
 ---
 
-<a href="../src/wazuh.py#L144"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L145"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `install_certificates`
 
@@ -77,7 +77,7 @@ Update Wazuh filebeat certificates.
 
 ---
 
-<a href="../src/wazuh.py#L164"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L165"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_agent_password`
 
@@ -97,7 +97,7 @@ Configure the agent password.
 
 ---
 
-<a href="../src/wazuh.py#L219"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_git`
 
@@ -123,7 +123,7 @@ Configure git.
 
 ---
 
-<a href="../src/wazuh.py#L277"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L278"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `pull_configuration_files`
 
@@ -142,7 +142,7 @@ Pull configuration files from the repository.
 
 ---
 
-<a href="../src/wazuh.py#L309"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L310"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `configure_filebeat_user`
 
@@ -167,7 +167,7 @@ Configure the filebeat user.
 
 ---
 
-<a href="../src/wazuh.py#L365"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L366"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `change_api_password`
 
@@ -195,7 +195,7 @@ Change Wazuh's API password for a given user.
 
 ---
 
-<a href="../src/wazuh.py#L429"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/wazuh.py#L430"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `generate_api_credentials`
 
@@ -206,6 +206,27 @@ generate_api_credentials() → dict[str, str]
 Generate the credentials for the default API users. 
 
 Returns: a dict containing the new credentials. 
+
+
+---
+
+<a href="../src/wazuh.py#L441"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `get_version`
+
+```python
+get_version(container: Container) → str
+```
+
+Get the Wazuh version. 
+
+
+
+**Arguments:**
+ 
+ - <b>`container`</b>:  the container in which to check the version. 
+
+Returns: the Wazuh version number. 
 
 
 ---

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,6 +143,7 @@ class WazuhServerCharm(CharmBaseWithState):
                     username, WAZUH_DEFAULT_API_CREDENTIALS[username], password
                 )
             self.app.add_secret(credentials, label=WAZUH_API_CREDENTIALS)
+        self.unit.set_workload_version(wazuh.get_version(container))
         self.unit.status = ops.ActiveStatus()
 
     @property

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -6,6 +6,7 @@
 """Wazuh operational logic."""
 
 import logging
+import re
 import secrets
 import string
 import typing
@@ -435,3 +436,17 @@ def generate_api_credentials() -> dict[str, str]:
         "wazuh": _generate_api_password(),
         "wazuh-wui": _generate_api_password(),
     }
+
+
+def get_version(container: ops.Container) -> str:
+    """Get the Wazuh version.
+
+    Arguments:
+        container: the container in which to check the version.
+
+    Returns: the Wazuh version number.
+    """
+    process = container.exec(["/var/ossec/bin/wazuh-control", "info"])
+    version_string, _ = process.wait_output()
+    version = re.search('^WAZUH_VERSION="(.*)"', version_string)
+    return version.group(1) if version else ""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,7 +54,9 @@ def test_invalid_state_reaches_blocked_status(state_from_charm_mock):
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
+@patch.object(wazuh, "get_version")
 def test_reconcile_reaches_active_status_when_repository_and_password_configured(
+    get_version_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -94,6 +96,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         wazuh_config=wazuh_config,
         custom_config_ssh_key="somekey",
     )
+    get_version_mock.return_value = "v4.9.2"
     harness = Harness(WazuhServerCharm)
     harness.begin()
     container = harness.model.unit.containers.get("wazuh-server")
@@ -120,6 +123,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         container=container, password=agent_password
     )
     pull_configuration_files_mock.assert_called_with(container)
+    get_version_mock.assert_called_with(container)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 
@@ -131,7 +135,9 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
+@patch.object(wazuh, "get_version")
 def test_reconcile_reaches_active_status_when_repository_and_password_not_configured(
+    get_version_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -167,6 +173,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         ),
         custom_config_ssh_key=None,
     )
+    get_version_mock.return_value = "v4.9.2"
     harness = Harness(WazuhServerCharm)
     harness.begin()
     container = harness.model.unit.containers.get("wazuh-server")
@@ -189,6 +196,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server/0",
         cluster_key,
     )
+    get_version_mock.assert_called_with(container)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
 

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -334,3 +334,21 @@ def test_generate_api_credentials() -> None:
 
     assert "wazuh" in credentials
     assert "wazuh-wui" in credentials
+
+
+def test_get_version() -> None:
+    """
+    arrange: mock the system call to fetch the version.
+    act: fetch the version.
+    assert: the version is correctly parsed from the output.
+    """
+    harness = Harness(ops.CharmBase, meta=CHARM_METADATA)
+    harness.begin_with_initial_hooks()
+    harness.handle_exec(
+        "wazuh-server",
+        ["/var/ossec/bin/wazuh-control", "info"],
+        result='WAZUH_VERSION="v4.9.2"\nWAZUH_REVISION="40921"\nWAZUH_TYPE="server"\n',
+    )
+    container = harness.charm.unit.get_container("wazuh-server")
+    version = wazuh.get_version(container)
+    assert "v4.9.2" == version


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Set workload version to the Wazuh version

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
