### PR TITLE
Expose wazuh API on port 55000

### DIFF
--- a/src-docs/traefik_route_observer.py.md
+++ b/src-docs/traefik_route_observer.py.md
@@ -22,7 +22,7 @@ The Traefik route relation observer.
  
  - <b>`hostname`</b>:  The unit's hostname. 
 
-<a href="../src/traefik_route_observer.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/traefik_route_observer.py#L32"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>function</kbd> `__init__`
 

--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -18,6 +18,7 @@ RELATION_NAME = "ingress"
 PORTS: dict[str, int] = {
     "conn_tcp": 1514,
     "enrole_tcp": 1515,
+    "api_tcp": 55000,
 }
 
 

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -66,6 +66,11 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                         "service": "juju-testing-observer-charm-service-enrole-tcp",
                         "rule": "ClientIP(`0.0.0.0/0`)",
                     },
+                    "juju-testing-observer-charm-api-tcp": {
+                        "entryPoints": ["api-tcp"],
+                        "service": "juju-testing-observer-charm-service-api-tcp",
+                        "rule": "ClientIP(`0.0.0.0/0`)",
+                    },
                 },
                 "services": {
                     "juju-testing-observer-charm-service-conn-tcp": {
@@ -80,6 +85,12 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                             "terminationDelay": 1000,
                         }
                     },
+                    "juju-testing-observer-charm-service-api-tcp": {
+                        "loadBalancer": {
+                            "servers": [{"address": "wazuh-server.local:55000"}],
+                            "terminationDelay": 1000,
+                        }
+                    },
                 },
             },
         },
@@ -87,6 +98,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
             "entryPoints": {
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
+                "api-tcp": {"address": ":55000"},
             }
         },
     )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Expose wazuh API on port 55000

### Rationale

<!-- The reason the change is needed -->
It is needed by the dashboard

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
