### PR TITLE
Fix syslog collection configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -38,6 +38,7 @@ class WazuhServerCharm(CharmBaseWithState):
 
     Attributes:
         master_fqdn: the FQDN for unit 0.
+        local_ip: the local IP.
         state: the charm state.
     """
 
@@ -126,6 +127,7 @@ class WazuhServerCharm(CharmBaseWithState):
             self.master_fqdn,
             self.unit.name,
             self.state.cluster_key,
+            self.local_ip,
         )
 
     # It doesn't make sense to split the logic further
@@ -320,6 +322,15 @@ class WazuhServerCharm(CharmBaseWithState):
         unit_name = f"{self.unit.name.split('/')[0]}-0"
         app_name = self.app.name
         return f"{unit_name}.{app_name}-endpoints"
+
+    @property
+    def local_ip(self) -> str:
+        """Fetch the local IP.
+
+        Returns: the local IP address.
+        """
+        binding = self.model.get_binding(WAZUH_PEER_RELATION_NAME)
+        return str(binding.network.bind_address)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -16,7 +16,7 @@ RELATION_NAME = "ingress"
 
 
 PORTS: dict[str, int] = {
-    "syslog_tcp_udp": 514,
+    "syslog_tcp": 514,
     "conn_tcp": 1514,
     "enrole_tcp": 1515,
     "api_tcp": 55000,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -120,6 +120,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
+        ip,
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
     wazuh_configure_agent_password_mock.assert_called_with(
@@ -208,6 +209,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
+        ip,
     )
     wazuh_reload_configuration_mock.assert_called_with(container)
     get_version_mock.assert_called_with(container)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import pytest
 from ops.testing import Harness
 
 import wazuh
-from charm import WazuhServerCharm
+from charm import WAZUH_PEER_RELATION_NAME, WazuhServerCharm
 from state import InvalidStateError, RecoverableStateError, State, WazuhConfig
 
 
@@ -105,6 +105,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
     get_version_mock.return_value = "v4.9.2"
     harness = Harness(WazuhServerCharm)
     harness.begin()
+    harness.add_relation(WAZUH_PEER_RELATION_NAME, harness.charm.app.name)
     container = harness.model.unit.containers.get("wazuh-server")
     assert container
     harness.set_can_connect(container, True)
@@ -120,7 +121,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
-        ip,
+        harness.charm.local_ip,
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
     wazuh_configure_agent_password_mock.assert_called_with(
@@ -190,6 +191,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
     get_version_mock.return_value = "v4.9.2"
     harness = Harness(WazuhServerCharm)
     harness.begin()
+    harness.add_relation(WAZUH_PEER_RELATION_NAME, harness.charm.app.name)
     container = harness.model.unit.containers.get("wazuh-server")
     assert container
     harness.set_can_connect(container, True)
@@ -209,7 +211,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
-        ip,
+        harness.charm.local_ip,
     )
     wazuh_reload_configuration_mock.assert_called_with(container)
     get_version_mock.assert_called_with(container)

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -56,9 +56,9 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
         {
             "tcp": {
                 "routers": {
-                    "juju-testing-observer-charm-syslog-tcp-udp": {
-                        "entryPoints": ["syslog-tcp-udp"],
-                        "service": "juju-testing-observer-charm-service-syslog-tcp-udp",
+                    "juju-testing-observer-charm-syslog-tcp": {
+                        "entryPoints": ["syslog-tcp"],
+                        "service": "juju-testing-observer-charm-service-syslog-tcp",
                         "rule": "ClientIP(`0.0.0.0/0`)",
                     },
                     "juju-testing-observer-charm-conn-tcp": {
@@ -78,7 +78,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     },
                 },
                 "services": {
-                    "juju-testing-observer-charm-service-syslog-tcp-udp": {
+                    "juju-testing-observer-charm-service-syslog-tcp": {
                         "loadBalancer": {
                             "servers": [{"address": "wazuh-server.local:514"}],
                             "terminationDelay": 1000,
@@ -107,7 +107,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
         },
         static={
             "entryPoints": {
-                "syslog-tcp-udp": {"address": ":514"},
+                "syslog-tcp": {"address": ":514"},
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
                 "api-tcp": {"address": ":55000"},

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -46,7 +46,8 @@ def test_update_configuration_when_on_master(monkeypatch: pytest.MonkeyPatch) ->
     container.push(wazuh.OSSEC_CONF_PATH, ossec_content, make_dirs=True)
 
     key = secrets.token_hex(32)
-    wazuh.update_configuration(container, indexer_ips, master_ip, "wazuh-server/0", key)
+    ip = "192.0.0.1"
+    wazuh.update_configuration(container, indexer_ips, master_ip, "wazuh-server/0", key, ip)
 
     filebeat_config = container.pull(wazuh.FILEBEAT_CONF_PATH, encoding="utf-8").read()
     filebeat_config_yaml = yaml.safe_load(filebeat_config)
@@ -87,7 +88,8 @@ def test_update_configuration_when_on_worker(monkeypatch: pytest.MonkeyPatch) ->
     container.push(wazuh.OSSEC_CONF_PATH, ossec_content, make_dirs=True)
 
     key = secrets.token_hex(32)
-    wazuh.update_configuration(container, indexer_ips, master_ip, "wazuh-server/1", key)
+    ip = "192.0.0.1"
+    wazuh.update_configuration(container, indexer_ips, master_ip, "wazuh-server/1", key, ip)
 
     filebeat_config = container.pull(wazuh.FILEBEAT_CONF_PATH, encoding="utf-8").read()
     filebeat_config_yaml = yaml.safe_load(filebeat_config)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Collect only over TCP
* Set the local IP to the IP of the container's interface

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
