### PR TITLE
Tls termination

### DIFF
--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -42,7 +42,7 @@ This is done by publishing a resource to Charmhub as described in the
 
 Wazuh Server is an application controlled by the `/var/ossec/bin/wazuh-control` script.
 
-Wazuh Server listens on ports 1514, 1515 and 55000; the first two serving the services for the agents to connect, and the last one serving the API.
+Wazuh Server listens on ports 514, 1514, 1515 and 55000; the first exposing a rsyslog service over TLS; the next two, the services for the agents to connect, and the last one serving the API.
 
 The workload that this container is running is defined in the [Wazuh Server rock](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml).
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -412,7 +412,7 @@ def _generate_syslog_snippets(local_ip: str) -> list[str]:
         """
         <localfile>
             <log_format>syslog</log_format>
-            <location>/var/ossec/logs/archive.log</location>
+            <location>/var/ossec/logs/archives/archives.log</location>
         </localfile>
 
         """,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -21,10 +21,7 @@ async def get_k8s_service_address(model: Model, service_name: str) -> str:
     Returns:
         The LoadBalancer service address as a string.
     """
-    command = [
-        f"-n {model.name}",
-        f"get service/{service_name}",
-        "-o=jsonpath={.status.loadBalancer.ingress[0].ip}",
-    ]
-    # sh.kubectl actually exists
-    return sh.kubectl(*command).strip("'")  # pylint: disable=no-member
+    # sh.kubectl.get.service actually exists
+    return sh.kubectl.get.service(  # pylint: disable=no-member
+        service_name, namespace=model.name, o="jsonpath={.status.loadBalancer.ingress[0].ip}"
+    )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -24,7 +24,7 @@ async def get_k8s_service_address(model: Model, service_name: str) -> str:
     command = [
         f"-n {model.name}",
         f"get service/{service_name}",
-        "-o=jsonpath='{.status.loadBalancer.ingress[0].ip}'",
+        "-o=jsonpath={.status.loadBalancer.ingress[0].ip}",
     ]
     # sh.kubectl actually exists
     return sh.kubectl(*command).strip("'")  # pylint: disable=no-member

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -24,7 +24,7 @@ async def get_k8s_service_address(model: Model, service_name: str) -> str:
     command = [
         f"-n {model.name}",
         f"get service/{service_name}",
-        "-o=jsonpath='{{.status.loadBalancer.ingress[0].ip}}'",
+        "-o=jsonpath='{.status.loadBalancer.ingress[0].ip}'",
     ]
     # sh.kubectl actually exists
     return sh.kubectl(*command).strip("'")  # pylint: disable=no-member

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration test helpers."""
+
+import logging
+
+import sh
+from juju.model import Model
+
+logger = logging.getLogger(__name__)
+
+
+async def get_k8s_service_address(model: Model, service_name: str) -> str:
+    """Get the address of a LoadBalancer Kubernetes service using kubectl.
+
+    Args:
+        model: the Juju model.
+        service_name: The name of the Kubernetes service.
+
+    Returns:
+        The LoadBalancer service address as a string.
+    """
+    command = [
+        f"-n {model.name}",
+        f"get service/{service_name}",
+        "-o=jsonpath='{{.status.loadBalancer.ingress[0].ip}}'",
+    ]
+    # sh.kubectl actually exists
+    return sh.kubectl(*command).strip("'")  # pylint: disable=no-member

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ async def test_api(model: Model, application: Application):
     await application.scale(2)
     await model.wait_for_idle(apps=[application.name], status="active", timeout=1400)
 
-    traefik_ip = await get_k8s_service_address(model, f"{APP_NAME}-lb")
+    traefik_ip = await get_k8s_service_address(model, "traefik-k8s-lb")
     response = requests.get(  # nosec
         f"https://{traefik_ip}:{wazuh.API_PORT}/security/user/authenticate",
         auth=("wazuh", state.WAZUH_USERS["wazuh"]["default_password"]),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -16,6 +16,7 @@ from juju.model import Model
 
 import state
 import wazuh
+from tests.integration.helpers import get_k8s_service_address
 
 logger = logging.getLogger(__name__)
 
@@ -28,24 +29,20 @@ async def test_api(model: Model, application: Application):
     """
     Arrange: deploy the charm together with related charms.
     Act: scale up to two units.
-    Assert: the default credentials are no longer valid for any of the units.
+    Assert: the default credentials are no longer valid for the API.
     """
     await application.scale(2)
     await model.wait_for_idle(apps=[application.name], status="active", timeout=1400)
-    status = await model.get_status()
-    # Type hints are not ok here
-    units = list(status.applications[application.name].units)  # type: ignore
-    for unit in units:
-        address = status["applications"][application.name]["units"][unit]["address"]
-        # Check the defaults are changed instead of the new creds
-        # https://github.com/juju/python-libjuju/issues/947
-        response = requests.get(  # nosec
-            f"https://{address}:{wazuh.API_PORT}/security/user/authenticate",
-            auth=("wazuh", state.WAZUH_USERS["wazuh"]["default_password"]),
-            timeout=10,
-            verify=False,
-        )
-        assert response.status_code == 401, response.content
+
+    traefik_ip = await get_k8s_service_address(model, f"{APP_NAME}-lb")
+    response = requests.get(  # nosec
+        f"https://{traefik_ip}:{wazuh.API_PORT}/security/user/authenticate",
+        auth=("wazuh", state.WAZUH_USERS["wazuh"]["default_password"]),
+        timeout=10,
+        verify=False,
+    )
+
+    assert response.status_code == 401, response.content
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -56,10 +56,11 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
         {
             "tcp": {
                 "routers": {
-                    "juju-testing-observer-charm-syslog-tcp": {
-                        "entryPoints": ["syslog-tcp"],
-                        "service": "juju-testing-observer-charm-service-syslog-tcp",
+                    "juju-testing-observer-charm-syslog-tls": {
+                        "entryPoints": ["syslog-tls"],
+                        "service": "juju-testing-observer-charm-service-syslog-tls",
                         "rule": "ClientIP(`0.0.0.0/0`)",
+                        "tls": {},
                     },
                     "juju-testing-observer-charm-conn-tcp": {
                         "entryPoints": ["conn-tcp"],
@@ -78,7 +79,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     },
                 },
                 "services": {
-                    "juju-testing-observer-charm-service-syslog-tcp": {
+                    "juju-testing-observer-charm-service-syslog-tls": {
                         "loadBalancer": {
                             "servers": [{"address": "wazuh-server.local:514"}],
                             "terminationDelay": 1000,
@@ -107,7 +108,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
         },
         static={
             "entryPoints": {
-                "syslog-tcp": {"address": ":514"},
+                "syslog-tls": {"address": ":514"},
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
                 "api-tcp": {"address": ":55000"},

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     pytest-asyncio
     pytest-operator
     requests
+    sh
     types-PyYAML
     types-requests
     -r{toxinidir}/requirements.txt
@@ -104,6 +105,7 @@ deps =
     pytest
     pytest-asyncio
     pytest-operator
+    sh
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO --keep-models -s {posargs}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* TLS termination for port 514
* Fix syslog file path
* Changed the API integration test to execise the Traefik configuration

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
