### PR TITLE
Simplify TLS certificates management

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -86,8 +86,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 self,
                 opensearch_relation_data,
                 certificates,
-                self.certificates.get_filebeat_csr().decode("utf-8"),
-                self.certificates.get_syslog_csr().decode("utf-8"),
+                self.certificates.get_csr().decode("utf-8"),
             )
         except InvalidStateError as exc:
             logger.error("Invalid charm configuration, %s", exc)
@@ -128,16 +127,16 @@ class WazuhServerCharm(CharmBaseWithState):
         wazuh.install_certificates(
             container=container,
             path=wazuh.FILEBEAT_CERTIFICATES_PATH,
-            private_key=self.certificates.get_filebeat_private_key(),
-            public_key=self.state.filebeat_certificate,
-            root_ca=self.state.filebeat_root_ca,
+            private_key=self.certificates.get_private_key(),
+            public_key=self.state.certificate,
+            root_ca=self.state.root_ca,
         )
         wazuh.install_certificates(
             container=container,
             path=wazuh.SYSLOG_CERTIFICATES_PATH,
-            private_key=self.certificates.get_syslog_private_key(),
-            public_key=self.state.syslog_certificate,
-            root_ca=self.state.syslog_root_ca,
+            private_key=self.certificates.get_private_key(),
+            public_key=self.state.certificate,
+            root_ca=self.state.root_ca,
         )
         wazuh.configure_filebeat_user(
             container, self.state.filebeat_username, self.state.filebeat_password

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -24,8 +24,7 @@ from state import (
 )
 
 
-@patch.object(CertificatesObserver, "get_filebeat_csr")
-@patch.object(CertificatesObserver, "get_syslog_csr")
+@patch.object(CertificatesObserver, "get_csr")
 @patch.object(State, "from_charm")
 def test_invalid_state_reaches_error_status(state_from_charm_mock, *_):
     """
@@ -42,8 +41,7 @@ def test_invalid_state_reaches_error_status(state_from_charm_mock, *_):
         harness.charm.state  # pylint: disable=pointless-statement
 
 
-@patch.object(CertificatesObserver, "get_filebeat_csr")
-@patch.object(CertificatesObserver, "get_syslog_csr")
+@patch.object(CertificatesObserver, "get_csr")
 @patch.object(State, "from_charm")
 def test_invalid_state_reaches_blocked_status(state_from_charm_mock, *_):
     """
@@ -60,8 +58,7 @@ def test_invalid_state_reaches_blocked_status(state_from_charm_mock, *_):
     assert harness.model.unit.status.name == ops.BlockedStatus().name
 
 
-@patch.object(CertificatesObserver, "get_filebeat_csr")
-@patch.object(CertificatesObserver, "get_syslog_csr")
+@patch.object(CertificatesObserver, "get_csr")
 @patch.object(State, "from_charm")
 def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
     """
@@ -90,10 +87,8 @@ def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
 @patch.object(wazuh, "configure_filebeat_user")
 @patch.object(wazuh, "reload_configuration")
 @patch.object(wazuh, "get_version")
-@patch.object(CertificatesObserver, "get_filebeat_csr")
-@patch.object(CertificatesObserver, "get_syslog_csr")
+@patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_active_status_when_repository_and_password_configured(
-    syslog_csr_mock,
     filebeat_csr_mock,
     get_version_mock,
     wazuh_reload_configuration_mock,
@@ -130,10 +125,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         agent_password=agent_password,
         api_credentials=api_credentials,
         cluster_key=cluster_key,
-        filebeat_certificate="filebeat_cert",
-        filebeat_root_ca="filebeat_root_ca",
-        syslog_certificate="syslog_cert",
-        syslog_root_ca="syslog_root_ca",
+        certificate="certificate",
+        root_ca="root_ca",
         indexer_ips=["10.0.0.1"],
         filebeat_username="user1",
         filebeat_password=password,
@@ -142,7 +135,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
     )
     get_version_mock.return_value = "v4.9.2"
     filebeat_csr_mock.return_value = b""
-    syslog_csr_mock.return_value = b""
     harness = Harness(WazuhServerCharm)
     harness.begin()
     harness.add_relation(WAZUH_PEER_RELATION_NAME, harness.charm.app.name)
@@ -158,15 +150,15 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
                 container=container,
                 path=wazuh.FILEBEAT_CERTIFICATES_PATH,
                 private_key=ANY,
-                public_key="filebeat_cert",
-                root_ca="filebeat_root_ca",
+                public_key="certificate",
+                root_ca="root_ca",
             ),
             call(
                 container=container,
                 path=wazuh.SYSLOG_CERTIFICATES_PATH,
                 private_key=ANY,
-                public_key="syslog_cert",
-                root_ca="syslog_root_ca",
+                public_key="certificate",
+                root_ca="root_ca",
             ),
         ]
     )
@@ -202,10 +194,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "configure_filebeat_user")
 @patch.object(wazuh, "reload_configuration")
 @patch.object(wazuh, "get_version")
-@patch.object(CertificatesObserver, "get_filebeat_csr")
-@patch.object(CertificatesObserver, "get_syslog_csr")
+@patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_active_status_when_repository_and_password_not_configured(
-    syslog_csr_mock,
     filebeat_csr_mock,
     get_version_mock,
     wazuh_reload_configuration_mock,
@@ -234,10 +224,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         agent_password=None,
         api_credentials=api_credentials,
         cluster_key=cluster_key,
-        filebeat_certificate="filebeat_cert",
-        filebeat_root_ca="filebeat_root_ca",
-        syslog_certificate="syslog_cert",
-        syslog_root_ca="syslog_root_ca",
+        certificate="certificate",
+        root_ca="root_ca",
         indexer_ips=["10.0.0.1"],
         filebeat_username="user1",
         filebeat_password=password,
@@ -250,7 +238,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
     )
     get_version_mock.return_value = "v4.9.2"
     filebeat_csr_mock.return_value = b""
-    syslog_csr_mock.return_value = b""
     harness = Harness(WazuhServerCharm)
     harness.begin()
     harness.add_relation(WAZUH_PEER_RELATION_NAME, harness.charm.app.name)
@@ -266,15 +253,15 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
                 container=container,
                 path=wazuh.FILEBEAT_CERTIFICATES_PATH,
                 private_key=ANY,
-                public_key="filebeat_cert",
-                root_ca="filebeat_root_ca",
+                public_key="certificate",
+                root_ca="root_ca",
             ),
             call(
                 container=container,
                 path=wazuh.SYSLOG_CERTIFICATES_PATH,
                 private_key=ANY,
-                public_key="syslog_cert",
-                root_ca="syslog_root_ca",
+                public_key="certificate",
+                root_ca="root_ca",
             ),
         ]
     )
@@ -312,8 +299,7 @@ def test_reconcile_reaches_waiting_status_when_cant_connect():
 
 
 @patch.object(State, "from_charm")
-@patch.object(CertificatesObserver, "get_filebeat_csr")
-@patch.object(CertificatesObserver, "get_syslog_csr")
+@patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_error_status_when_no_state(state_from_charm_mock, *_):
     """
     arrange: mock the state to raise an exception.

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -36,22 +36,12 @@ def test_state_invalid_opensearch_relation_data(opensearch_relation_data):
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     with pytest.raises(state.InvalidStateError):
@@ -60,10 +50,9 @@ def test_state_invalid_opensearch_relation_data(opensearch_relation_data):
             opensearch_relation_data,
             provider_certificates,
             "1",
-            "2",
         )
     with pytest.raises(state.RecoverableStateError):
-        state.State.from_charm(mock_charm, opensearch_relation_data, [], "1", "2")
+        state.State.from_charm(mock_charm, opensearch_relation_data, [], "1")
 
 
 def test_state_without_proxy():
@@ -94,22 +83,12 @@ def test_state_without_proxy():
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     charm_state = state.State.from_charm(
@@ -117,7 +96,6 @@ def test_state_without_proxy():
         opensearch_relation_data,
         provider_certificates,
         "1",
-        "2",
     )
 
     assert charm_state.api_credentials
@@ -126,10 +104,8 @@ def test_state_without_proxy():
     assert charm_state.indexer_ips == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
-    assert charm_state.filebeat_certificate == "filebeat_cert"
-    assert charm_state.filebeat_root_ca == "filebeat_root_ca"
-    assert charm_state.syslog_certificate == "syslog_cert"
-    assert charm_state.syslog_root_ca == "syslog_root_ca"
+    assert charm_state.certificate == "certificate"
+    assert charm_state.root_ca == "root_ca"
     assert charm_state.custom_config_repository is None
     assert charm_state.custom_config_ssh_key is None
     assert charm_state.proxy.http_proxy is None
@@ -166,22 +142,12 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
     monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "http://squid.proxy:3228/")
     monkeypatch.setenv("JUJU_CHARM_HTTPS_PROXY", "https://squid.proxy:3228/")
@@ -192,16 +158,13 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
         opensearch_relation_data,
         provider_certificates,
         "1",
-        "2",
     )
     assert charm_state.api_credentials
     assert charm_state.api_credentials["value"] == value
     assert charm_state.cluster_key == value
     assert charm_state.indexer_ips == endpoints
-    assert charm_state.filebeat_certificate == "filebeat_cert"
-    assert charm_state.filebeat_root_ca == "filebeat_root_ca"
-    assert charm_state.syslog_certificate == "syslog_cert"
-    assert charm_state.syslog_root_ca == "syslog_root_ca"
+    assert charm_state.certificate == "certificate"
+    assert charm_state.root_ca == "root_ca"
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
     assert charm_state.custom_config_repository is None
@@ -242,22 +205,12 @@ def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     charm_state = state.State.from_charm(
@@ -265,7 +218,6 @@ def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
         opensearch_relation_data,
         provider_certificates,
         "1",
-        "2",
     )
     with pytest.raises(state.RecoverableStateError):
         charm_state.proxy  # pylint: disable=pointless-statement
@@ -307,22 +259,12 @@ def test_state_when_repository_secret_not_found(monkeypatch: pytest.MonkeyPatch)
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     with pytest.raises(state.RecoverableStateError):
@@ -331,7 +273,6 @@ def test_state_when_repository_secret_not_found(monkeypatch: pytest.MonkeyPatch)
             opensearch_relation_data,
             provider_certificates,
             "1",
-            "2",
         )
 
 
@@ -370,22 +311,12 @@ def test_state_when_agent_password_secret_not_found(monkeypatch: pytest.MonkeyPa
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     with pytest.raises(state.RecoverableStateError):
@@ -394,7 +325,6 @@ def test_state_when_agent_password_secret_not_found(monkeypatch: pytest.MonkeyPa
             opensearch_relation_data,
             provider_certificates,
             "1",
-            "2",
         )
 
 
@@ -434,22 +364,12 @@ def test_state_when_repository_secret_invalid(monkeypatch: pytest.MonkeyPatch):
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     with pytest.raises(state.RecoverableStateError):
@@ -458,7 +378,6 @@ def test_state_when_repository_secret_invalid(monkeypatch: pytest.MonkeyPatch):
             opensearch_relation_data,
             provider_certificates,
             "1",
-            "2",
         )
 
 
@@ -497,22 +416,12 @@ def test_state_when_agent_secret_invalid(monkeypatch: pytest.MonkeyPatch):
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     with pytest.raises(state.RecoverableStateError):
@@ -521,7 +430,6 @@ def test_state_when_agent_secret_invalid(monkeypatch: pytest.MonkeyPatch):
             opensearch_relation_data,
             provider_certificates,
             "1",
-            "2",
         )
 
 
@@ -565,22 +473,12 @@ def test_state_when_repository_secret_valid(monkeypatch: pytest.MonkeyPatch):
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     charm_state = state.State.from_charm(
@@ -588,17 +486,14 @@ def test_state_when_repository_secret_valid(monkeypatch: pytest.MonkeyPatch):
         opensearch_relation_data,
         provider_certificates,
         "1",
-        "2",
     )
 
     assert charm_state.cluster_key == value
     assert charm_state.indexer_ips == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
-    assert charm_state.filebeat_certificate == "filebeat_cert"
-    assert charm_state.filebeat_root_ca == "filebeat_root_ca"
-    assert charm_state.syslog_certificate == "syslog_cert"
-    assert charm_state.syslog_root_ca == "syslog_root_ca"
+    assert charm_state.certificate == "certificate"
+    assert charm_state.root_ca == "root_ca"
     assert str(charm_state.custom_config_repository) == custom_config_repository
     assert charm_state.custom_config_ssh_key == value
     assert charm_state.proxy.http_proxy is None
@@ -643,22 +538,12 @@ def test_state_when_agent_password_secret_valid(monkeypatch: pytest.MonkeyPatch)
             relation_id="certificates-provider/1",
             application_name="application",
             csr="1",
-            certificate="filebeat_cert",
-            ca="filebeat_root_ca",
+            certificate="certificate",
+            ca="root_ca",
             chain=[],
             revoked=False,
             expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
-        certificates.ProviderCertificate(
-            relation_id="certificates-provider/1",
-            application_name="application",
-            csr="2",
-            certificate="syslog_cert",
-            ca="syslog_root_ca",
-            chain=[],
-            revoked=False,
-            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
-        ),
+        )
     ]
 
     charm_state = state.State.from_charm(
@@ -666,17 +551,14 @@ def test_state_when_agent_password_secret_valid(monkeypatch: pytest.MonkeyPatch)
         opensearch_relation_data,
         provider_certificates,
         "1",
-        "2",
     )
 
     assert charm_state.cluster_key == value
     assert charm_state.indexer_ips == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
-    assert charm_state.filebeat_certificate == "filebeat_cert"
-    assert charm_state.filebeat_root_ca == "filebeat_root_ca"
-    assert charm_state.syslog_certificate == "syslog_cert"
-    assert charm_state.syslog_root_ca == "syslog_root_ca"
+    assert charm_state.certificate == "certificate"
+    assert charm_state.root_ca == "root_ca"
     assert charm_state.agent_password == value
     assert charm_state.custom_config_repository is None
     assert charm_state.custom_config_ssh_key is None


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Use one single TLS certificate instead of two

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
