### PR TITLE
add white line at the end of the key file

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -244,7 +244,7 @@ def configure_git(
     if custom_config_ssh_key:
         container.push(
             RSA_PATH,
-            custom_config_ssh_key,
+            f"{custom_config_ssh_key}\n",
             encoding="utf-8",
             make_dirs=True,
             user=WAZUH_USER,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
If the white line is missing the authentication will fail, so adding an additional white line makes the configuration more resilent

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
