### PR TITLE
Fix syslog group creation

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -26,7 +26,7 @@ parts:
       chmod 755 $CRAFT_OVERLAY/etc
       groupadd -R $CRAFT_OVERLAY --gid 2000 prometheus
       useradd -R $CRAFT_OVERLAY --system --gid 2000 --uid 2000 --home /srv/prometheus prometheus
-      groupadd -R $CRAFT_OVERLAY --gid 2001 syslog
+      groupadd -R $CRAFT_OVERLAY --gid 2001 adm
       useradd -R $CRAFT_OVERLAY --system --gid 2001 --uid 2001 --home /home/syslog syslog
   utils:
     plugin: nil

--- a/src/charm.py
+++ b/src/charm.py
@@ -270,7 +270,6 @@ class WazuhServerCharm(CharmBaseWithState):
                         "--path.data /var/lib/filebeat --path.logs /var/log/filebeat'"
                     ),
                     "startup": "enabled",
-                    "environment": environment,
                 },
                 "rsyslog": {
                     "override": "replace",
@@ -288,7 +287,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 "wazuh-ready": {
                     "override": "replace",
                     "level": "ready",
-                    "period": "20s",
+                    "period": "60s",
                     "threshold": 10,
                     "exec": {
                         "command": (


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Set the group to match the one in the default configuration

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
