### PR TITLE
Do not reload the wazuh service when reconciling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -223,8 +223,6 @@ class WazuhServerCharm(CharmBaseWithState):
         self._configure_installation(container)
         container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
         container.replan()
-        # Reload since the service might not have been restarted
-        wazuh.reload_configuration(container)
         self._configure_users()
         # Fetch the new wazuh layer, which has different env vars
         logger.debug("Reconfiguring pebble layers")

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -151,22 +151,6 @@ def update_configuration(
     _update_wazuh_configuration(container, ip_ports, master_address, unit_name, cluster_key)
 
 
-def reload_configuration(container: ops.Container) -> None:
-    """Reload the workload configuration.
-
-    Arguments:
-        container: the container for which to update the configuration.
-
-    Raises:
-        WazuhInstallationError: if an error occurs while installing.
-    """
-    proc = container.exec(["/var/ossec/bin/wazuh-control", "reload"])
-    try:
-        proc.wait_output()
-    except (ops.pebble.ChangeError, ops.pebble.ExecError) as exc:
-        raise WazuhInstallationError("Error reloading the wazuh daemon.") from exc
-
-
 def install_certificates(
     container: ops.Container, path: Path, public_key: str, private_key: str, root_ca: str
 ) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -85,13 +85,11 @@ def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
-@patch.object(wazuh, "reload_configuration")
 @patch.object(wazuh, "get_version")
 @patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_active_status_when_repository_and_password_configured(
     filebeat_csr_mock,
     get_version_mock,
-    wazuh_reload_configuration_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -177,7 +175,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         container, str(wazuh_config.custom_config_repository), "somekey"
     )
     pull_configuration_files_mock.assert_called_with(container)
-    wazuh_reload_configuration_mock.assert_called_with(container)
     get_version_mock.assert_called_with(container)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 
@@ -192,13 +189,11 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
-@patch.object(wazuh, "reload_configuration")
 @patch.object(wazuh, "get_version")
 @patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_active_status_when_repository_and_password_not_configured(
     filebeat_csr_mock,
     get_version_mock,
-    wazuh_reload_configuration_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -276,7 +271,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server/0",
         cluster_key,
     )
-    wazuh_reload_configuration_mock.assert_called_with(container)
     get_version_mock.assert_called_with(container)
     assert harness.model.unit.status.name == ops.ActiveStatus().name
 

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -105,27 +105,6 @@ def test_update_configuration_when_on_worker(monkeypatch: pytest.MonkeyPatch) ->
     assert address.text == master_ip
 
 
-def test_reload_configuration_when_restart_fails(monkeypatch: pytest.MonkeyPatch) -> None:
-    """
-    arrange: mock the service restart so that it errors.
-    act: reload the service.
-    assert: a WazuhInstallationError is raised.
-    """
-    harness = Harness(ops.CharmBase, meta=CHARM_METADATA)
-    harness.begin_with_initial_hooks()
-    container = harness.charm.unit.get_container("wazuh-server")
-    exec_process = unittest.mock.MagicMock()
-    exec_error = ops.pebble.ExecError(
-        command=["/var/ossec/bin/wazuh-control", "reload"], exit_code=1, stdout="", stderr=""
-    )
-    exec_process.wait_output = unittest.mock.MagicMock(side_effect=exec_error)
-    exec_mock = unittest.mock.MagicMock(return_value=exec_process)
-    monkeypatch.setattr(container, "exec", exec_mock)
-
-    with pytest.raises(wazuh.WazuhInstallationError):
-        wazuh.reload_configuration(container)
-
-
 def test_install_certificates() -> None:
     """
     arrange: do nothing.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Do not reload the wazuh service when reconciling since it doesn't have any difference at this point. Configuration files are not actively pulled

### Rationale

<!-- The reason the change is needed -->
Reloading the service is flaky and requires more careful execution

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
