### PR TITLE
Fix readiness pebble check for wazuh

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -281,10 +281,10 @@ class WazuhServerCharm(CharmBaseWithState):
                     "threshold": 10,
                     "exec": {
                         "command": (
-                            "sh -c 'sleep 1; "
+                            "sh -c \"sleep 1; "
                             "curl -k "
                             f"--user wazuh:{shlex.quote(self.state.api_credentials['wazuh'])} "
-                            f"{wazuh.AUTH_ENDPOINT}'"
+                            f"{wazuh.AUTH_ENDPOINT}\""
                         )
                     },
                 },

--- a/src/charm.py
+++ b/src/charm.py
@@ -281,10 +281,10 @@ class WazuhServerCharm(CharmBaseWithState):
                     "threshold": 10,
                     "exec": {
                         "command": (
-                            "sh -c \"sleep 1; "
+                            'sh -c "sleep 1; '
                             "curl -k "
                             f"--user wazuh:{shlex.quote(self.state.api_credentials['wazuh'])} "
-                            f"{wazuh.AUTH_ENDPOINT}\""
+                            f'{wazuh.AUTH_ENDPOINT}"'
                         )
                     },
                 },


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fix an error in especial characters escaping causing the readiness pebble check for wazuh to fail

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
