### PR TITLE
Fix ryslog port configuration

### DIFF
--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -16,7 +16,7 @@ RELATION_NAME = "ingress"
 
 
 PORTS: dict[str, int] = {
-    "syslog_tcp": 514,
+    "syslog_tcp": 6514,
     "conn_tcp": 1514,
     "enrole_tcp": 1515,
     "api_tcp": 55000,

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -80,7 +80,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                 "services": {
                     "juju-testing-observer-charm-service-syslog-tcp": {
                         "loadBalancer": {
-                            "servers": [{"address": "wazuh-server.local:514"}],
+                            "servers": [{"address": "wazuh-server.local:6514"}],
                             "terminationDelay": 1000,
                         }
                     },
@@ -107,7 +107,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
         },
         static={
             "entryPoints": {
-                "syslog-tcp": {"address": ":514"},
+                "syslog-tcp": {"address": ":6514"},
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
                 "api-tcp": {"address": ":55000"},


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
