### PR TITLE
Fix syslog configuration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -181,16 +181,13 @@ class WazuhServerCharm(CharmBaseWithState):
                     logger.debug("Could not authenticate user %s with default password.", username)
             else:
                 logger.debug("Configuring non-default user %s", username)
-                try:
-                    token = wazuh.authenticate_user("wazuh", credentials["wazuh"])
-                    password = credentials[username]
-                    if not password:
-                        password = wazuh.generate_api_password()
-                    wazuh.create_readonly_api_user(username, password, token)
-                    credentials[username] = password
-                    logger.debug("Created API user %s", username)
-                except wazuh.WazuhInstallationError:
-                    logger.debug("Could not add user %s.", username)
+                token = wazuh.authenticate_user("wazuh", credentials["wazuh"])
+                password = credentials[username]
+                if not password:
+                    password = wazuh.generate_api_password()
+                wazuh.create_readonly_api_user(username, password, token)
+                credentials[username] = password
+                logger.debug("Created API user %s", username)
             # Store the new credentials alongside the existing ones
             try:
                 secret = self.model.get_secret(label=state.WAZUH_API_CREDENTIALS)

--- a/src/charm.py
+++ b/src/charm.py
@@ -261,7 +261,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 "rsyslog": {
                     "override": "replace",
                     "summary": "rsyslog",
-                    "command": "rsyslogd -n -f /etc/rsyslog.d/wazuh.conf",
+                    "command": "rsyslogd -n -f /etc/rsyslog.conf",
                     "startup": "enabled",
                 },
             },

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -405,7 +405,8 @@ def authenticate_user(username: str, password: str) -> str:
     Returns: the JWT token
 
     Raises:
-        WazuhAuthenticationError: if an authentication error occurs.
+        WazuhAuthenticationError: if the user can't authenticate.
+        WazuhInstallationError: if any error occurs.
     .
     """
     # The certificates might be self signed and there's no security hardening in
@@ -424,10 +425,10 @@ def authenticate_user(username: str, password: str) -> str:
         response.raise_for_status()
         token = response.json()["data"]["token"] if response.json()["data"] else None
         if token is None:
-            raise WazuhAuthenticationError(f"Response for {username} does not contain token.")
+            raise WazuhInstallationError(f"Response for {username} does not contain token.")
         return token
     except requests.exceptions.RequestException as exc:
-        raise WazuhAuthenticationError from exc
+        raise WazuhInstallationError from exc
 
 
 def change_api_password(username: str, password: str, token: str) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,6 +76,7 @@ def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
 
 
 # pylint: disable=too-many-arguments, too-many-locals, too-many-positional-arguments
+@patch.object(wazuh, "create_readonly_api_user")
 @patch.object(wazuh, "authenticate_user")
 @patch.object(wazuh, "change_api_password")
 @patch.object(State, "from_charm")
@@ -180,6 +181,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments
+@patch.object(wazuh, "create_readonly_api_user")
 @patch.object(wazuh, "authenticate_user")
 @patch.object(wazuh, "change_api_password")
 @patch.object(State, "from_charm")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Fix the path to the rsyslog configuration file
* Error whenever the charm fails to set up the users

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
