### PR TITLE
Fix rsyslog permissions

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -26,7 +26,8 @@ parts:
       chmod 755 $CRAFT_OVERLAY/etc
       groupadd -R $CRAFT_OVERLAY --gid 2000 prometheus
       useradd -R $CRAFT_OVERLAY --system --gid 2000 --uid 2000 --home /srv/prometheus prometheus
-      useradd -R $CRAFT_OVERLAY --system --gid adm --uid 2001 --home /home/syslog syslog
+      groupadd -R $CRAFT_OVERLAY --gid 2001 syslog
+      useradd -R $CRAFT_OVERLAY --system --gid 2001 --uid 2001 --home /home/syslog syslog
   utils:
     plugin: nil
     stage-packages:
@@ -71,6 +72,7 @@ parts:
       chroot $CRAFT_OVERLAY bash -c 'echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list'
       chroot $CRAFT_OVERLAY apt-get update
       chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt-get install wazuh-manager=4.9.2-1 --yes"
+      chmod 755 /var/ossec/logs/
       umount --recursive $CRAFT_OVERLAY/dev
       umount $CRAFT_OVERLAY/proc
       umount $CRAFT_OVERLAY/etc/resolv.conf


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Fix user setup
* * Fix filesystem permissions

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
