### PR TITLE
Fix file permissions for rsyslog

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -72,7 +72,7 @@ parts:
       chroot $CRAFT_OVERLAY bash -c 'echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list'
       chroot $CRAFT_OVERLAY apt-get update
       chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt-get install wazuh-manager=4.9.2-1 --yes"
-      chroot $CRAFT_OVERLAY bash -c "chmod 755 /var/ossec/logs/"
+      chroot $CRAFT_OVERLAY bash -c "chmod 777 /var/ossec/logs/"
       umount --recursive $CRAFT_OVERLAY/dev
       umount $CRAFT_OVERLAY/proc
       umount $CRAFT_OVERLAY/etc/resolv.conf

--- a/src/charm.py
+++ b/src/charm.py
@@ -126,6 +126,8 @@ class WazuhServerCharm(CharmBaseWithState):
             private_key=self.certificates.get_private_key(),
             public_key=self.state.certificate,
             root_ca=self.state.root_ca,
+            user=wazuh.FILEBEAT_USER,
+            group=wazuh.FILEBEAT_USER,
         )
         wazuh.install_certificates(
             container=container,
@@ -133,6 +135,8 @@ class WazuhServerCharm(CharmBaseWithState):
             private_key=self.certificates.get_private_key(),
             public_key=self.state.certificate,
             root_ca=self.state.root_ca,
+            user=wazuh.SYSLOG_USER,
+            group=wazuh.SYSLOG_USER,
         )
         wazuh.configure_filebeat_user(
             container, self.state.filebeat_username, self.state.filebeat_password

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -151,6 +151,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
                 private_key=ANY,
                 public_key="certificate",
                 root_ca="root_ca",
+                user="root",
+                group="root",
             ),
             call(
                 container=container,
@@ -158,6 +160,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
                 private_key=ANY,
                 public_key="certificate",
                 root_ca="root_ca",
+                user="syslog",
+                group="syslog",
             ),
         ]
     )
@@ -252,6 +256,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
                 private_key=ANY,
                 public_key="certificate",
                 root_ca="root_ca",
+                user="root",
+                group="root",
             ),
             call(
                 container=container,
@@ -259,6 +265,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
                 private_key=ANY,
                 public_key="certificate",
                 root_ca="root_ca",
+                user="syslog",
+                group="syslog",
             ),
         ]
     )

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -120,6 +120,8 @@ def test_install_certificates() -> None:
         private_key="private_key",
         public_key="public_key",
         root_ca="root_ca",
+        user="root",
+        group="root",
     )
 
     assert (


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
