### PR TITLE
Change rsync log path

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -72,7 +72,6 @@ parts:
       chroot $CRAFT_OVERLAY bash -c 'echo "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages.wazuh.com/4.x/apt/ stable main" | tee -a /etc/apt/sources.list.d/wazuh.list'
       chroot $CRAFT_OVERLAY apt-get update
       chroot $CRAFT_OVERLAY bash -c "DEBIAN_FRONTEND=noninteractive apt-get install wazuh-manager=4.9.2-1 --yes"
-      chroot $CRAFT_OVERLAY bash -c "chmod 777 /var/ossec/logs/"
       umount --recursive $CRAFT_OVERLAY/dev
       umount $CRAFT_OVERLAY/proc
       umount $CRAFT_OVERLAY/etc/resolv.conf

--- a/rock/wazuh.conf
+++ b/rock/wazuh.conf
@@ -22,4 +22,4 @@ $InputTCPServerRun 6514
 # Storing Messages from a Remote System into a specific File 
 #if $fromhost-ip startswith '<ENDPOINT_IP>' then /var/log/endpoint_logs 
 #& ~
-*.* /var/ossec/logs/archive.log
+*.* /var/log/rsyslog.log


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Change log path and remove unnecessary permissions

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
