### PR TITLE
Remove termination delay from Traefik's configuration

### DIFF
--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -90,7 +90,7 @@ class TraefikRouteObserver(Object):
             services[service_name] = {
                 "loadBalancer": {
                     "servers": [{"address": f"{self.hostname}:{port}"}],
-                    "terminationDelay": 1000,
+                    "terminationDelay": -1,
                 }
             }
         return {

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -81,25 +81,25 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     "juju-testing-observer-charm-service-syslog-tcp": {
                         "loadBalancer": {
                             "servers": [{"address": "wazuh-server.local:6514"}],
-                            "terminationDelay": 1000,
+                            "terminationDelay": -1,
                         }
                     },
                     "juju-testing-observer-charm-service-conn-tcp": {
                         "loadBalancer": {
                             "servers": [{"address": "wazuh-server.local:1514"}],
-                            "terminationDelay": 1000,
+                            "terminationDelay": -1,
                         }
                     },
                     "juju-testing-observer-charm-service-enrole-tcp": {
                         "loadBalancer": {
                             "servers": [{"address": "wazuh-server.local:1515"}],
-                            "terminationDelay": 1000,
+                            "terminationDelay": -1,
                         }
                     },
                     "juju-testing-observer-charm-service-api-tcp": {
                         "loadBalancer": {
                             "servers": [{"address": "wazuh-server.local:55000"}],
-                            "terminationDelay": 1000,
+                            "terminationDelay": -1,
                         }
                     },
                 },


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Remove termination delay from Traefik's configuration

### Rationale

<!-- The reason the change is needed -->
Hopefully fixes the rsyslog TLS termination error

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
