### PR TITLE
Remove rediness checks

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,6 @@
 
 import logging
 import secrets
-import shlex
 import typing
 
 import ops
@@ -275,20 +274,6 @@ class WazuhServerCharm(CharmBaseWithState):
                     "level": "alive",
                     "tcp": {"port": wazuh.API_PORT},
                 },
-                "wazuh-ready": {
-                    "override": "replace",
-                    "level": "ready",
-                    "period": "30s",
-                    "threshold": 10,
-                    "exec": {
-                        "command": (
-                            'sh -c "sleep 1; '
-                            "curl -k "
-                            f"--user wazuh:{shlex.quote(self.state.api_credentials['wazuh'])} "
-                            f'{wazuh.AUTH_ENDPOINT}"'
-                        )
-                    },
-                },
             },
         }
 
@@ -319,20 +304,6 @@ class WazuhServerCharm(CharmBaseWithState):
                         "WAZUH_API_PASSWORD": self.state.api_credentials["prometheus"],
                     },
                 }
-            },
-            "checks": {
-                "prometheus-alive": {
-                    "override": "replace",
-                    "level": "alive",
-                    "tcp": {"port": 5000},
-                },
-                "prometheus-ready": {
-                    "override": "replace",
-                    "period": "30s",
-                    "threshold": 10,
-                    "level": "alive",
-                    "exec": {"command": "sh -c 'sleep 1; curl http://localhost:5000/metrics'"},
-                },
             },
         }
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Remove Wazuh API and prometheus rediness checks

### Rationale

<!-- The reason the change is needed -->
They are failing randomly and pod restarts are making diagnosis more difficult

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
