### PR TITLE
Disable syslog imklog module

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -101,6 +101,10 @@ parts:
       - gnutls-bin
       - rsyslog
       - rsyslog-gnutls
+    override-stage: |
+      # Disable reading logs from the kernel module
+      sed -i '/imklog/s/^/#/' $CRAFT_PART_INSTALL/etc/rsyslog.conf
+      craftctl default
   rsyslog-config:
     plugin: dump
     source: .


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Disable syslog imklog module which provides kernel logging support

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
