### PR TITLE
Remove additional filebeat package

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -42,7 +42,6 @@ parts:
     build-packages:
       - yq
     stage-packages:
-      - filebeat
       - net-tools
     override-stage: |
       mkdir -p $CRAFT_PART_INSTALL/etc/filebeat/certs

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -84,7 +84,9 @@ def _update_filebeat_configuration(container: ops.Container, ip_ports: list[str]
     filebeat_config = container.pull(FILEBEAT_CONF_PATH, encoding="utf-8").read()
     filebeat_config_yaml = yaml.safe_load(filebeat_config)
     filebeat_config_yaml["output.elasticsearch"]["hosts"] = ip_ports
-    container.push(FILEBEAT_CONF_PATH, yaml.safe_dump(filebeat_config_yaml), encoding="utf-8")
+    container.push(
+        FILEBEAT_CONF_PATH, yaml.safe_dump(filebeat_config_yaml, sort_keys=False), encoding="utf-8"
+    )
 
 
 # Won't sacrify cohesion and readability to make pylint happier


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Remove additional filebeat package
* Do not reorder filebeat's config file keys

### Rationale

<!-- The reason the change is needed -->
The package is already installed from the Wazuh repository

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
