### PR TITLE
Fix filebeat user permissions

### DIFF
--- a/src/opensearch_observer.py
+++ b/src/opensearch_observer.py
@@ -25,7 +25,9 @@ class OpenSearchObserver(Object):
         """
         super().__init__(charm, RELATION_NAME)
         self._charm = charm
-        self.opensearch = OpenSearchRequires(charm, RELATION_NAME, "placeholder")
+        self.opensearch = OpenSearchRequires(
+            charm, RELATION_NAME, "placeholder", extra_user_roles="admin"
+        )
 
         self.framework.observe(
             self._charm.on.opensearch_client_relation_changed, self._charm.reconcile


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Request openesarch a user with admin permissions

### Rationale

<!-- The reason the change is needed -->
Filebeat needs admin permissions so that it can create indexes for event logging

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
