### PR TITLE
Feat/support local testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,4 @@ def pytest_addoption(parser):
     parser.addoption("--charm-file", action="store")
     parser.addoption("--kube-config", action="store", default="~/.kube/config")
     parser.addoption("--wazuh-server-image", action="store")
+    parser.addoption("--single-node-indexer", action="store_true")

--- a/tests/integration/config_single_node_index.sh
+++ b/tests/integration/config_single_node_index.sh
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 #!/bin/bash
 #
 # When run with --single-index-node parameter, integration tests need 

--- a/tests/integration/config_single_node_index.sh
+++ b/tests/integration/config_single_node_index.sh
@@ -24,7 +24,7 @@ curl -k -u $CREDS -X PUT https://$IP:9200/_index_template/default-replicas -H "C
 echo
 
 echo "Updating existing indices"
-for index in $(curl -k -u $CREDS https://10.14.1.206:9200/_cat/indices  | awk '{print $3}' | grep -v .opendistro_security); do
+for index in $(curl -k -u $CREDS https://$IP:9200/_cat/indices  | awk '{print $3}' | grep -v .opendistro_security); do
 	echo $index
 	curl -k -u $CREDS -X PUT https://$IP:9200/$index/_settings -H "Content-Type: application/json" -d '{ "index": { "number_of_replicas": 0 } }'
 	echo

--- a/tests/integration/config_single_node_index.sh
+++ b/tests/integration/config_single_node_index.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# When run with --single-index-node parameter, integration tests need 
+# opensearch to be configured in a specific way.
+#
+
+if ! juju show-application wazuh-indexer &>/dev/null; then
+	echo "No wazuh-indexer found (are you on the right model?)"
+	exit 1
+fi
+
+echo "Fetching admin password through secrets as the get-password action would fail if the charm is blocked"
+PASSWORD=$(for secret in $(juju secrets | tail +2 | awk '{print $1}'); do juju show-secret $secret --reveal | grep 'admin-password:'; done | awk '{print $2}')
+CREDS="admin:$PASSWORD"
+
+echo "Retrieving unit IP"
+IP=$(juju show-unit wazuh-indexer/0 | grep 'public-address:' | awk '{print $2}')
+
+echo "Updating cluster to not have replicates for new indices"
+REQ='{ "index_patterns": ["*"], "template": { "settings": { "number_of_replicas": 0 } } }'
+curl -k -u $CREDS -X PUT https://$IP:9200/_index_template/default-replicas -H "Content-Type: application/json" -d "$REQ"
+echo
+
+echo "Updating existing indices"
+for index in $(curl -k -u $CREDS https://10.14.1.206:9200/_cat/indices  | awk '{print $3}' | grep -v .opendistro_security); do
+	echo $index
+	curl -k -u $CREDS -X PUT https://$IP:9200/$index/_settings -H "Content-Type: application/json" -d '{ "index": { "number_of_replicas": 0 } }'
+	echo
+done
+
+echo "Waiting 5s for health to turn green"
+sleep 5
+curl -k -u $CREDS https://$IP:9200/_cat/indices -H "Content-Type: application/json"

--- a/tests/integration/config_single_node_index.sh
+++ b/tests/integration/config_single_node_index.sh
@@ -15,7 +15,7 @@ if ! juju show-application wazuh-indexer &>/dev/null; then
 fi
 
 echo "Fetching admin password through secrets as the get-password action would fail if the charm is blocked"
-PASSWORD=$(for secret in $(juju secrets | tail +2 | awk '{print $1}'); do juju show-secret $secret --reveal; done | awk '/admin-password:/{print $2}')
+PASSWORD=$(for secret in $(juju secrets | tail +2 | awk '{print $1}'); do juju show-secret "$secret" --reveal; done | awk '/admin-password:/{print $2}')
 CREDS="admin:$PASSWORD"
 
 echo "Retrieving unit IP"
@@ -23,16 +23,16 @@ IP=$(juju show-unit wazuh-indexer/0 | grep 'public-address:' | awk '{print $2}')
 
 echo "Updating cluster to not have replicates for new indices"
 REQ='{ "index_patterns": ["*"], "template": { "settings": { "number_of_replicas": 0 } } }'
-curl -k -u $CREDS -X PUT https://$IP:9200/_index_template/default-replicas -H "Content-Type: application/json" -d "$REQ"
+curl -k -u "$CREDS" -X PUT "https://$IP:9200/_index_template/default-replicas" -H "Content-Type: application/json" -d "$REQ"
 echo
 
 echo "Updating existing indices"
-for index in $(curl -k -u $CREDS https://$IP:9200/_cat/indices  | awk '{print $3}' | grep -v .opendistro_security); do
-	echo $index
-	curl -k -u $CREDS -X PUT https://$IP:9200/$index/_settings -H "Content-Type: application/json" -d '{ "index": { "number_of_replicas": 0 } }'
+for index in $(curl -k -u "$CREDS" "https://$IP:9200/_cat/indices"  | awk '{print $3}' | grep -v .opendistro_security); do
+	echo "$index"
+	curl -k -u "$CREDS" -X PUT "https://$IP:9200/$index/_settings" -H "Content-Type: application/json" -d '{ "index": { "number_of_replicas": 0 } }'
 	echo
 done
 
 echo "Waiting 5s for health to turn green"
 sleep 5
-curl -k -u $CREDS https://$IP:9200/_cat/indices -H "Content-Type: application/json"
+curl -k -u "$CREDS" "https://$IP:9200/_cat/indices" -H "Content-Type: application/json"

--- a/tests/integration/config_single_node_index.sh
+++ b/tests/integration/config_single_node_index.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
+#
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-#!/bin/bash
 #
 # When run with --single-index-node parameter, integration tests need 
 # opensearch to be configured in a specific way.

--- a/tests/integration/config_single_node_index.sh
+++ b/tests/integration/config_single_node_index.sh
@@ -4,13 +4,15 @@
 # opensearch to be configured in a specific way.
 #
 
+set -euo pipefail
+
 if ! juju show-application wazuh-indexer &>/dev/null; then
 	echo "No wazuh-indexer found (are you on the right model?)"
 	exit 1
 fi
 
 echo "Fetching admin password through secrets as the get-password action would fail if the charm is blocked"
-PASSWORD=$(for secret in $(juju secrets | tail +2 | awk '{print $1}'); do juju show-secret $secret --reveal | grep 'admin-password:'; done | awk '{print $2}')
+PASSWORD=$(for secret in $(juju secrets | tail +2 | awk '{print $1}'); do juju show-secret $secret --reveal; done | awk '/admin-password:/{print $2}')
 CREDS="admin:$PASSWORD"
 
 echo "Retrieving unit IP"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -156,19 +156,31 @@ async def application_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy the charm."""
     # Deploy the charm and wait for active/idle status
+    no_deploy = pytestconfig.getoption("--no-deploy")
     resources = {
         "wazuh-server-image": pytestconfig.getoption("--wazuh-server-image"),
     }
-    application = await model.deploy(f"./{charm}", resources=resources, trust=True)
-    await model.integrate(
-        f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
-        application.name,
-    )
-    await model.integrate(
-        f"localhost:admin/{self_signed_certificates.model.name}.{self_signed_certificates.name}",
-        application.name,
-    )
-    await model.integrate(traefik.name, application.name)
+    wazuh_server_app = "wazuh-server"
+    if no_deploy and wazuh_server_app in model.applications:
+        logger.warning("Using existing application: %s", wazuh_server_app)
+        application = model.applications[wazuh_server_app]
+    else:
+        application = await model.deploy(f"./{charm}", resources=resources, trust=True)
+
+    relations = [r.key for r in model.relations]
+    if "wazuh-server:opensearch-client wazuh-indexer:opensearch-client" not in relations:
+        await model.integrate(
+            f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
+            application.name,
+        )
+    if "wazuh-server:certificates self-signed-certificates:certificates" not in relations:
+        await model.integrate(
+            f"localhost:admin/{self_signed_certificates.model.name}.{self_signed_certificates.name}",
+            application.name,
+        )
+    if "wazuh-server:ingress traefik-k8s:traefik-route" not in relations:
+        await model.integrate(traefik.name, application.name)
+
     await model.wait_for_idle(
         apps=[traefik.name], status="active", raise_on_error=False, timeout=1800
     )


### PR DESCRIPTION
Support the "--no-deploy" flag and won't complain if some applications and relations are already present.

Especially useful when testing locally as we don't have to redeploy the dependencies every time.

The second part is the "--single-indexer-node" option which only deploys a single opensearch node. There are still some manual operation to do through a script for the opensearch cluster to behave correctly in this setup.