### PR TITLE
Explicit offer_url

### DIFF
--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -100,7 +100,7 @@ resource "juju_integration" "wazuh_server_certificates" {
   }
 
   application {
-    offer_url = juju_offer.self_signed_certificates.url
+    offer_url = "${var.controller}:${juju_offer.self_signed_certificates.url}"
   }
 }
 
@@ -279,6 +279,6 @@ resource "juju_integration" "wazuh_server_indexer" {
   }
 
   application {
-    offer_url = juju_offer.wazuh_indexer.url
+    offer_url = "${var.controller}:${juju_offer.wazuh_indexer.url}"
   }
 }

--- a/terraform/product/variables.tf
+++ b/terraform/product/variables.tf
@@ -1,6 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+variable "controller" {
+  description = "Reference to the Juju controller to deploy application to."
+  type        = string
+}
+
 variable "model" {
   description = "Reference to the k8s Juju model to deploy application to."
   type        = string


### PR DESCRIPTION
If the full URL (with the controller name) not provided, the terraform provider returns an error.
