### PR TITLE
Add wazuh-api credentials relation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -92,6 +92,8 @@ provides:
     interface: grafana_dashboard
   metrics-endpoint:
     interface: prometheus_scrape
+  wazuh-api:
+    interface: wazuh_api_client
 requires:
   certificates:
     interface: tls-certificates

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -212,7 +212,7 @@ class WazuhApiRequires(ops.Object):
             relation: the relation to retrieve the data from.
 
         Returns:
-            WazuhApiRelationData: the relation data.
+            WazuhApiRelationData: the relation data if found.
         """
         assert relation.app
         relation_data = relation.data[relation.app]
@@ -230,10 +230,9 @@ class WazuhApiRequires(ops.Object):
                 user=user,
                 password=password,
             )
-        except ops.model.ModelError as exc:
-            raise SecretError(
-                f'Could not consume secret {relation_data.get("user_credentials_secret")}'
-            ) from exc
+        except ops.model.ModelError:
+            logger.debug("Could not fetch secret %s", relation_data.get("user_credentials_secret"))
+            return None
 
     def _is_relation_data_valid(self, relation: ops.Relation) -> bool:
         """Validate the relation data.

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -1,0 +1,293 @@
+# Copyright 2025 Canonical Ltd.
+# Licensed under the Apache2.0. See LICENSE file in charm source for details.
+
+"""Library to manage the integration with the Wazuh Server charm.
+
+This library contains the Requires and Provides classes for handling the integration
+between an application and a charm providing the `wazuh-apli-client` integration.
+This library also contains a `WazuhApiRelationData` class to wrap the data that will
+be shared via the integration.
+
+### Requirer Charm
+
+```python
+
+from charms.wazuh_server.v0.wazuh_api import WazuhApiDataAvailableEvent, WazuhApiServerRequires
+
+class WazuhApiServerRequirerCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.wazuh_api = wazuh_api.WazuhApiServerRequires(self)
+        self.framework.observe(self.smtp.on.wazuh_api_data_available, self._handler)
+        ...
+
+    def _handler(self, events: WazuhApiDataAvailableEvent) -> None:
+        ...
+
+```
+
+As shown above, the library provides a custom event to handle the scenario in
+which new Wazuh API data has been added or updated.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+from charms.wazuh_server.v0.wazuh_api import import WazuhApiServerProvides
+
+class WazuhApiPServerroviderCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.wazuh_api = WazuhApiServerProvides(self)
+        ...
+
+```
+The WazuhApiServerProvides object wraps the list of relations into a `relations` property
+and provides an `update_relation_data` method to update the relation data by passing
+a `WazuhApiRelationData` data object.
+
+```python
+class WazuhApiServerProviderCharm(ops.CharmBase):
+    ...
+
+    def _on_config_changed(self, _) -> None:
+        for relation in self.model.relations[self.wazuh_api.relation_name]:
+            self.wazuh_api.update_relation_data(relation, self._get_wazuh_api_data())
+
+```
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "f0b9836db9604a9491247244109c24e6"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+PYDEPS = ["pydantic>=2"]
+
+# pylint: disable=wrong-import-position
+import itertools
+import logging
+import typing
+from typing import Dict, Optional
+
+import ops
+from pydantic import AnyHttpUrl, BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+RELATION_NAME = "wazuh-api-client"
+WAZUH_API_KEY_SECRET_LABEL = "wazuh-api-credentials"
+
+
+class SecretError(Exception):
+    """Common ancestor for Secrets related exceptions."""
+
+
+class WazuhApiRelationData(BaseModel):
+    """Represent the relation data.
+
+    Attributes:
+        endpoint: The API endpoint.
+        user: The user to authenticate against the API.
+        password: TThe password to authenticate against the API.
+        secret_user: The secret ID containing the API credentials.
+    """
+
+    endpoint: AnyHttpUrl
+    user: str
+    password: str
+    secret_user: str
+
+    def to_relation_data(self) -> Dict[str, str]:
+        """Convert an instance of SmtpRelationData to the relation representation.
+
+        Returns:
+            Dict containing the representation.
+        """
+        return {
+            "endpoint": str(self.endpoint),
+            "secret_user": self.secret_user,
+        }
+
+
+class WazuhApiDataAvailableEvent(ops.RelationEvent):
+    """Event emitted when relation data has changed.
+
+    Attributes:
+        endpoint: The API endpoint.
+        user: The user to authenticate against the API.
+        password: TThe password to authenticate against the API.
+    """
+
+    @property
+    def endpoint(self) -> AnyHttpUrl:
+        """Fetch the endpoint from the relation."""
+        assert self.relation.app
+        return AnyHttpUrl(typing.cast(str, self.relation.data[self.relation.app].get("endpoint")))
+
+    @property
+    def _credentials(self) -> tuple[str, str]:
+        """Fetch the API credentials from the relation."""
+        assert self.relation.app
+        relation_data = self.relation.data[self.relation.app]
+        try:
+            credentials = self.framework.model.get_secret(id=relation_data.get("secret_user"))
+            user = typing.cast(str, credentials.get_content().get("user"))
+            password = typing.cast(str, credentials.get_content().get("password"))
+            return (user, password)
+        except ops.model.ModelError as exc:
+            raise SecretError(
+                f'Could not consume secret {relation_data.get("secret_user")}'
+            ) from exc
+
+    @property
+    def user(self) -> str:
+        """Fetch the user from the relation."""
+        assert self.relation.app
+        return self._credentials[0]
+
+    @property
+    def password(self) -> str:
+        """Fetch the password from the relation."""
+        assert self.relation.app
+        return self._credentials[1]
+
+
+class WazuhApiRequiresEvents(ops.CharmEvents):
+    """Wazuh API events.
+
+    This class defines the events that a requirer can emit.
+
+    Attributes:
+        wazuh_api_data_available: the WazuhApiDataAvailableEvent.
+    """
+
+    wazuh_api_data_available = ops.EventSource(WazuhApiDataAvailableEvent)
+
+
+class WazuhApiRequires(ops.Object):
+    """Requirer side of the Wazuh API client relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = WazuhApiRequiresEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def get_relation_data(self) -> Optional[WazuhApiRelationData]:
+        """Retrieve the relation data.
+
+        Returns:
+            WazuhApiRelationData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        return self._get_relation_data_from_relation(relation) if relation else None
+
+    def _get_relation_data_from_relation(
+        self, relation: ops.Relation
+    ) -> WazuhApiRelationData | None:
+        """Retrieve the relation data.
+
+        Args:
+            relation: the relation to retrieve the data from.
+
+        Returns:
+            WazuhApiRelationData: the relation data.
+        """
+        assert relation.app
+        relation_data = relation.data[relation.app]
+        if not relation_data:
+            return None
+
+        secret_id = typing.cast(str, relation_data.get("secret_user"))
+        try:
+            credentials = self.model.get_secret(id=secret_id)
+            user = typing.cast(str, credentials.get_content().get("user"))
+            password = typing.cast(str, credentials.get_content().get("password"))
+            return WazuhApiRelationData(
+                endpoint=AnyHttpUrl(typing.cast(str, relation_data.get("endpoint"))),
+                secret_user=secret_id,
+                user=user,
+                password=password,
+            )
+        except ops.model.ModelError as exc:
+            raise SecretError(
+                f'Could not consume secret {relation_data.get("secret_user")}'
+            ) from exc
+
+    def _is_relation_data_valid(self, relation: ops.Relation) -> bool:
+        """Validate the relation data.
+
+        Args:
+            relation: the relation to validate.
+
+        Returns:
+            true: if the relation data is valid.
+        """
+        try:
+            _ = self._get_relation_data_from_relation(relation)
+            return True
+        except ValidationError as ex:
+            error_fields = set(
+                itertools.chain.from_iterable(error["loc"] for error in ex.errors())
+            )
+            error_field_str = " ".join(f"{f}" for f in error_fields)
+            logger.warning("Error validation the relation data %s", error_field_str)
+            return False
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        assert event.relation.app
+        relation_data = event.relation.data[event.relation.app]
+        if relation_data:
+            if self._is_relation_data_valid(event.relation):
+                self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
+
+
+class WazuhApiProvides(ops.Object):
+    """Provider side of the Wazuh API relation."""
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def update_relation_data(
+        self, relation: ops.Relation, wazuh_api_data: WazuhApiRelationData
+    ) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            wazuh_api_data: a WazuhApiRelationData instance wrapping the data to be updated.
+        """
+        relation_data = wazuh_api_data.to_relation_data()
+        relation.data[self.charm.model.app].update(relation_data)

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -143,7 +143,7 @@ class WazuhApiDataAvailableEvent(ops.RelationEvent):
             user = typing.cast(str, credentials.get_content().get("user"))
             password = typing.cast(str, credentials.get_content().get("password"))
             return (user, password)
-        except ops.model.ModelError as exc:
+        except ops.SecretNotFoundError as exc:
             raise SecretError(
                 f'Could not consume secret {relation_data.get("user_credentials_secret")}'
             ) from exc

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -12,12 +12,12 @@ be shared via the integration.
 
 ```python
 
-from charms.wazuh_server.v0.wazuh_api import WazuhApiDataAvailableEvent, WazuhApiServerRequires
+from charms.wazuh_server.v0.wazuh_api import WazuhApiDataAvailableEvent, WazuhApiRequires
 
-class WazuhApiServerRequirerCharm(ops.CharmBase):
+class WazuhApiRequirerCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.wazuh_api = wazuh_api.WazuhApiServerRequires(self)
+        self.wazuh_api = wazuh_api.WazuhApiRequires(self)
         self.framework.observe(self.wazuh_api.on.wazuh_api_data_available, self._handler)
         ...
 
@@ -34,21 +34,21 @@ which new Wazuh API data has been added or updated.
 Following the previous example, this is an example of the provider charm.
 
 ```python
-from charms.wazuh_server.v0.wazuh_api import import WazuhApiServerProvides
+from charms.wazuh_server.v0.wazuh_api import import WazuhApiProvides
 
 class WazuhApiPServerroviderCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.wazuh_api = WazuhApiServerProvides(self)
+        self.wazuh_api = WazuhApiProvides(self)
         ...
 
 ```
-The WazuhApiServerProvides object wraps the list of relations into a `relations` property
+The WazuhApiProvides object wraps the list of relations into a `relations` property
 and provides an `update_relation_data` method to update the relation data by passing
 a `WazuhApiRelationData` data object.
 
 ```python
-class WazuhApiServerProviderCharm(ops.CharmBase):
+class WazuhApiProviderCharm(ops.CharmBase):
     ...
 
     def _on_config_changed(self, _) -> None:

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -81,7 +81,7 @@ from pydantic import AnyHttpUrl, BaseModel, ValidationError
 
 logger = logging.getLogger(__name__)
 
-RELATION_NAME = "wazuh-api-client"
+RELATION_NAME = "wazuh-api"
 WAZUH_API_KEY_SECRET_LABEL = "wazuh-api-credentials"
 
 

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -263,7 +263,9 @@ class WazuhApiRequires(ops.Object):
         relation_data = event.relation.data[event.relation.app]
         if relation_data:
             if self._is_relation_data_valid(event.relation):
-                self.on.smtp_data_available.emit(event.relation, app=event.app, unit=event.unit)
+                self.on.wazuh_api_data_available.emit(
+                    event.relation, app=event.app, unit=event.unit
+                )
 
 
 class WazuhApiProvides(ops.Object):

--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -36,7 +36,7 @@ Following the previous example, this is an example of the provider charm.
 ```python
 from charms.wazuh_server.v0.wazuh_api import import WazuhApiProvides
 
-class WazuhApiPServerroviderCharm(ops.CharmBase):
+class WazuhApiProviderCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.wazuh_api = WazuhApiProvides(self)

--- a/src/certificates_observer.py
+++ b/src/certificates_observer.py
@@ -64,7 +64,8 @@ class CertificatesObserver(Object):
             if not content or renew:
                 private_key = certificates.generate_private_key().decode()
                 content["key"] = private_key
-                secret.set_content(content=content)
+                if dict(secret.get_content(refresh=True)) != content:
+                    secret.set_content(content=content)
             private_key = secret.get_content().get("key")
         except ops.SecretNotFoundError:
             logger.debug("Secret for private key not found. One will be generated.")
@@ -123,7 +124,8 @@ class CertificatesObserver(Object):
         secret = self._charm.model.get_secret(label=label)
         content = secret.get_content()
         content["csr"] = csr.decode("utf-8")
-        secret.set_content(content=content)
+        if dict(secret.get_content(refresh=True)) != content:
+            secret.set_content(content=content)
         return csr
 
     def _on_certificates_relation_joined(self, event: ops.RelationJoinedEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -223,7 +223,8 @@ class WazuhServerCharm(CharmBaseWithState):
             # Store the new credentials alongside the existing ones
             try:
                 secret = self.model.get_secret(label=state.WAZUH_API_CREDENTIALS)
-                secret.set_content(credentials)
+                if dict(secret.get_content(refresh=True)) != credentials:
+                    secret.set_content(credentials)
                 logger.debug("Updated secret %s with credentials", secret.id)
             except ops.SecretNotFoundError:
                 if self.unit.is_leader():
@@ -235,7 +236,8 @@ class WazuhServerCharm(CharmBaseWithState):
         }
         try:
             secret = self.model.get_secret(label=wazuh_api.WAZUH_API_KEY_SECRET_LABEL)
-            secret.set_content(api_key_secret_content)
+            if dict(secret.get_content(refresh=True)) != api_key_secret_content:
+                secret.set_content(api_key_secret_content)
             logger.debug("Updated secret %s with API credentials", secret.id)
         except ops.SecretNotFoundError:
             if self.unit.is_leader():

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,7 @@ class WazuhServerCharm(CharmBaseWithState):
                     ),
                     user="wazuh-wui",
                     password=self.state.api_credentials["wazuh-wui"],
-                    user_credentials_secret=secret.id,
+                    user_credentials_secret=secret.get_info().id,
                 )
                 relation = self.model.get_relation(wazuh_api.RELATION_NAME)
                 self._wazuh_api.update_relation_data(relation, relation_data)

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,7 @@ import typing
 
 import ops
 import pydantic
+from charms.wazuh_server.v0 import wazuh_api
 from ops import pebble
 
 import certificates_observer
@@ -19,7 +20,6 @@ import opensearch_observer
 import state
 import traefik_route_observer
 import wazuh
-from charms.wazuh_server.v0 import wazuh_api
 from state import (
     WAZUH_CLUSTER_KEY_SECRET_LABEL,
     CharmBaseWithState,

--- a/src/charm.py
+++ b/src/charm.py
@@ -203,7 +203,7 @@ class WazuhServerCharm(CharmBaseWithState):
                     logger.debug("Added secret %s with credentials", secret.id)
         api_key_secret_content = {
             "user": "wazuh-wui",
-            "password": self.state.api_credentials["wazuh_wui"],
+            "password": self.state.api_credentials["wazuh-wui"],
         }
         try:
             secret = self.model.get_secret(label=wazuh_api.WAZUH_API_KEY_SECRET_LABEL)

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,7 +91,7 @@ class WazuhServerCharm(CharmBaseWithState):
                     endpoint=pydantic.AnyHttpUrl(f"https://{self.external_hostname}:55000"),
                     user="wazuh-wui",
                     password=self.state.api_credentials["wazuh-wui"],
-                    secret_user=secret.id,
+                    user_credentials_secret=secret.id,
                 )
                 self._wazuh_api.update_relation_data(event.relation, relation_data)
             except ops.SecretNotFoundError:

--- a/src/charm.py
+++ b/src/charm.py
@@ -97,7 +97,8 @@ class WazuhServerCharm(CharmBaseWithState):
                     user_credentials_secret=secret.get_info().id,
                 )
                 relation = self.model.get_relation(wazuh_api.RELATION_NAME)
-                self._wazuh_api.update_relation_data(relation, relation_data)
+                if relation:
+                    self._wazuh_api.update_relation_data(relation, relation_data)
             except ops.SecretNotFoundError as exc:
                 raise InvalidStateError from exc
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -261,10 +261,10 @@ class WazuhServerCharm(CharmBaseWithState):
             self.unit.status = ops.WaitingStatus("Waiting for status to be available.")
             return
         self._configure_installation(container)
-        self._populate_wazuh_api_relation_data()
         container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
         container.replan()
         self._configure_users()
+        self._populate_wazuh_api_relation_data()
         # Fetch the new wazuh layer, which has different env vars
         logger.debug("Reconfiguring pebble layers")
         container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ import opensearch_observer
 import state
 import traefik_route_observer
 import wazuh
-from lib.charms.wazuh_server.v0 import wazuh_api
+from charms.wazuh_server.v0 import wazuh_api
 from state import (
     WAZUH_CLUSTER_KEY_SECRET_LABEL,
     CharmBaseWithState,

--- a/src/charm.py
+++ b/src/charm.py
@@ -88,7 +88,9 @@ class WazuhServerCharm(CharmBaseWithState):
             try:
                 secret = self.model.get_secret(label=wazuh_api.WAZUH_API_KEY_SECRET_LABEL)
                 relation_data = wazuh_api.WazuhApiRelationData(
-                    endpoint=pydantic.AnyHttpUrl(f"https://{self.external_hostname}:55000"),
+                    endpoint=pydantic.AnyHttpUrl(
+                        f"https://{self.external_hostname}:{wazuh.API_PORT}"
+                    ),
                     user="wazuh-wui",
                     password=self.state.api_credentials["wazuh-wui"],
                     user_credentials_secret=secret.id,
@@ -338,7 +340,7 @@ class WazuhServerCharm(CharmBaseWithState):
                     "on-failure": "restart",
                     "environment": {
                         "WAZUH_API_HOST": "localhost",
-                        "WAZUH_API_PORT": "55000",
+                        "WAZUH_API_PORT": f"{wazuh.API_PORT}",
                         "WAZUH_API_USERNAME": "prometheus",
                         "WAZUH_API_PASSWORD": self.state.api_credentials["prometheus"],
                     },

--- a/src/charm.py
+++ b/src/charm.py
@@ -272,6 +272,7 @@ class WazuhServerCharm(CharmBaseWithState):
         logger.debug("Reconfiguring pebble layers")
         container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
         container.add_layer("prometheus", self._prometheus_pebble_layer, combine=True)
+        logger.error(self._prometheus_pebble_layer)
         container.replan()
         self.unit.set_workload_version(wazuh.get_version(container))
         self.unit.status = ops.ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -313,6 +313,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 "wazuh-alive": {
                     "override": "replace",
                     "level": "alive",
+                    "threshold": 10,
                     "tcp": {"port": wazuh.API_PORT},
                 },
             },

--- a/src/traefik_route_observer.py
+++ b/src/traefik_route_observer.py
@@ -11,6 +11,8 @@ import ops
 from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
 from ops.framework import Object
 
+import wazuh
+
 logger = logging.getLogger(__name__)
 RELATION_NAME = "ingress"
 
@@ -19,7 +21,7 @@ PORTS: dict[str, int] = {
     "syslog_tcp": 6514,
     "conn_tcp": 1514,
     "enrole_tcp": 1515,
-    "api_tcp": 55000,
+    "api_tcp": wazuh.API_PORT,
 }
 
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -443,7 +443,7 @@ def authenticate_user(username: str, password: str) -> str:
     # container filesystem is compromised
     try:
         session = requests.Session()
-        retries = requests.adapters.Retry(connect=10, backoff_factor=0.2)
+        retries = requests.adapters.Retry(connect=10, backoff_factor=0.2, status_forcelist=[500])
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
         response = session.get(  # nosec
             AUTH_ENDPOINT,

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -16,6 +16,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import ops
 import requests
+import requests.adapters
 import yaml
 
 # Bandit classifies this import as vulnerable. For more details, see
@@ -441,6 +442,9 @@ def authenticate_user(username: str, password: str) -> str:
     # passing them to the request since tampering with `localhost` would mean the
     # container filesystem is compromised
     try:
+        session = requests.Session()
+        retries = requests.adapters.Retry(connect=10)
+        session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
         response = requests.get(  # nosec
             AUTH_ENDPOINT,
             auth=(username, password),

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -445,7 +445,7 @@ def authenticate_user(username: str, password: str) -> str:
         session = requests.Session()
         retries = requests.adapters.Retry(connect=10, backoff_factor=0.2)
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
-        response = requests.get(  # nosec
+        response = session.get(  # nosec
             AUTH_ENDPOINT,
             auth=(username, password),
             timeout=10,

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -443,7 +443,7 @@ def authenticate_user(username: str, password: str) -> str:
     # container filesystem is compromised
     try:
         session = requests.Session()
-        retries = requests.adapters.Retry(connect=10)
+        retries = requests.adapters.Retry(connect=10, backoff_factor=0.2)
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
         response = requests.get(  # nosec
             AUTH_ENDPOINT,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -81,6 +81,7 @@ async def traefik_fixture(
         app_name,
         application_name=app_name,
         channel="latest/edge",
+        revision=233,
         trust=True,
         config={"external_hostname": "wazuh-server.local"},
     )

--- a/tests/unit/test_library_wazuh_api.py
+++ b/tests/unit/test_library_wazuh_api.py
@@ -8,6 +8,8 @@ import ops
 from charms.wazuh_server.v0 import wazuh_api
 from ops.testing import Harness
 
+import wazuh
+
 REQUIRER_METADATA = """
 name: wazuh-api-consumer
 requires:
@@ -23,7 +25,7 @@ provides:
 """
 
 SAMPLE_RELATION_DATA = {
-    "endpoint": "https://example.wazuh:55000/",
+    "endpoint": f"https://example.wazuh:{wazuh.API_PORT}/",
     "user_credentials_secret": (
         "secret://59060ecc-0495-4a80-8006-5f1fc13fd783/cjqub6vubg2s77p3nio0"
     ),

--- a/tests/unit/test_library_wazuh_api.py
+++ b/tests/unit/test_library_wazuh_api.py
@@ -1,0 +1,169 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Wazuh API library unit tests"""
+import secrets
+
+import ops
+from charms.wazuh_server.v0 import wazuh_api
+from ops.testing import Harness
+
+REQUIRER_METADATA = """
+name: wazuh-api-consumer
+requires:
+  wazuh-api:
+    interface: wazuh_api_client
+"""
+
+PROVIDER_METADATA = """
+name: wazuh-api-producer
+provides:
+  wazuh-api:
+    interface: wazuh_api_client
+"""
+
+SAMPLE_RELATION_DATA = {
+    "endpoint": "https://example.wazuh:55000/",
+    "secret_user": "secret://59060ecc-0495-4a80-8006-5f1fc13fd783/cjqub6vubg2s77p3nio0",
+}
+
+
+class WazuhApiRequirerCharm(ops.CharmBase):
+    """Class for requirer charm testing."""
+
+    def __init__(self, *args):
+        """Init method for the class.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+        """
+        super().__init__(*args)
+        self.wazuh_api = wazuh_api.WazuhApiRequires(self)
+        self.events = []
+        self.framework.observe(self.on.wazuh_api_relation_changed, self._record_event)
+
+    def _record_event(self, event: ops.EventBase) -> None:
+        """Record emitted event in the event list.
+
+        Args:
+            event: event.
+        """
+        self.events.append(event)
+
+
+class WazuhApiProviderCharm(ops.CharmBase):
+    """Class for provider charm testing."""
+
+    def __init__(self, *args):
+        """Init method for the class.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+        """
+        super().__init__(*args)
+        self.wazuh_api = wazuh_api.WazuhApiProvides(self)
+        self.events = []
+        self.framework.observe(self.on.wazuh_api_relation_changed, self._record_event)
+
+    def _record_event(self, event: ops.EventBase) -> None:
+        """Record emitted event in the event list.
+
+        Args:
+            event: event.
+        """
+        self.events.append(event)
+
+
+def test_wazuh_api_provider_update_relation_data():
+    """
+    arrange: instantiate a WazuhApiProviderCharm object and add an wazuh-api relation.
+    act: update the relation data.
+    assert: the relation data is updated.
+    """
+    harness = Harness(WazuhApiProviderCharm, meta=PROVIDER_METADATA)
+    harness.begin()
+    harness.set_leader(True)
+    harness.add_relation("wazuh-api", "wazuh-api-provider")
+    relation = harness.model.get_relation("wazuh-api")
+
+    relation_data = wazuh_api.WazuhApiRelationData(
+        endpoint=SAMPLE_RELATION_DATA["endpoint"],
+        secret_user=SAMPLE_RELATION_DATA["secret_user"],
+        user="wazuh-wui",
+        password=secrets.token_hex(),
+    )
+    harness.charm.wazuh_api.update_relation_data(relation, relation_data)
+
+    assert relation
+    data = relation.data[harness.model.app]
+    assert data["endpoint"] == str(relation_data.endpoint)
+    assert data["secret_user"] == relation_data.secret_user
+    assert "user" not in data
+    assert "password" not in data
+
+
+def test_wazuh_api_relation_data_to_relation_data():
+    """
+    arrange: instantiate a WazuhApiRelationData object.
+    act: obtain the relation representation.
+    assert: the relation representation is correct.
+    """
+    relation_data = wazuh_api.WazuhApiRelationData(
+        endpoint=SAMPLE_RELATION_DATA["endpoint"],
+        secret_user=SAMPLE_RELATION_DATA["secret_user"],
+        user="wazuh-wui",
+        password=secrets.token_hex(),
+    )
+    relation_data = relation_data.to_relation_data()
+
+    assert relation_data == SAMPLE_RELATION_DATA
+
+
+def test_requirer_charm_with_valid_relation_data_emits_event():
+    """
+    arrange: set up a charm.
+    act: add an wazuh-api relation.
+    assert: an WazuhApiDataAvailable event containing the relation data is emitted.
+    """
+    harness = Harness(WazuhApiRequirerCharm, meta=REQUIRER_METADATA)
+    harness.begin()
+
+    password = secrets.token_hex()
+    secret_id = harness.add_user_secret({"user": "wazuh-wui", "password": password})
+    harness.grant_secret(secret_id, "wazuh-api-consumer")
+    SAMPLE_RELATION_DATA["secret_user"] = secret_id
+    harness.add_relation("wazuh-api", "wazuh-api-provider", app_data=SAMPLE_RELATION_DATA)
+    relation_data = harness.charm.wazuh_api.get_relation_data()
+
+    assert relation_data
+    assert str(relation_data.endpoint) == SAMPLE_RELATION_DATA["endpoint"]
+    assert relation_data.secret_user == SAMPLE_RELATION_DATA["secret_user"]
+    assert relation_data.user == "wazuh-wui"
+    assert relation_data.password == password
+
+
+def test_requirer_charm_with_invalid_relation_data_doesnt_emit_event():
+    """
+    arrange: set up a charm.
+    act: add an wazuh-api relation changed event with invalid data.
+    assert: an WazuhApiDataAvailable event is not emitted.
+    """
+    harness = Harness(WazuhApiRequirerCharm, meta=REQUIRER_METADATA)
+    harness.begin()
+    harness.add_relation("wazuh-api", "wazuh-api-provider", app_data={})
+
+    assert len(harness.charm.events) == 0
+
+
+def test_requirer_charm_get_relation_data_without_relation_data():
+    """
+    arrange: set up a charm with wazuh-api relation without any relation data.
+    act: call get_relation_data function.
+    assert: get_relation_data should return None.
+    """
+    harness = Harness(WazuhApiRequirerCharm, meta=REQUIRER_METADATA)
+    harness.begin()
+    harness.set_leader(True)
+    harness.add_relation("wazuh-api", "wazuh-api-provider", app_data={})
+
+    assert harness.charm.wazuh_api.get_relation_data() is None

--- a/tests/unit/test_library_wazuh_api.py
+++ b/tests/unit/test_library_wazuh_api.py
@@ -24,7 +24,9 @@ provides:
 
 SAMPLE_RELATION_DATA = {
     "endpoint": "https://example.wazuh:55000/",
-    "secret_user": "secret://59060ecc-0495-4a80-8006-5f1fc13fd783/cjqub6vubg2s77p3nio0",
+    "user_credentials_secret": (
+        "secret://59060ecc-0495-4a80-8006-5f1fc13fd783/cjqub6vubg2s77p3nio0"
+    ),
 }
 
 
@@ -88,7 +90,7 @@ def test_wazuh_api_provider_update_relation_data():
 
     relation_data = wazuh_api.WazuhApiRelationData(
         endpoint=SAMPLE_RELATION_DATA["endpoint"],
-        secret_user=SAMPLE_RELATION_DATA["secret_user"],
+        user_credentials_secret=SAMPLE_RELATION_DATA["user_credentials_secret"],
         user="wazuh-wui",
         password=secrets.token_hex(),
     )
@@ -97,7 +99,7 @@ def test_wazuh_api_provider_update_relation_data():
     assert relation
     data = relation.data[harness.model.app]
     assert data["endpoint"] == str(relation_data.endpoint)
-    assert data["secret_user"] == relation_data.secret_user
+    assert data["user_credentials_secret"] == relation_data.user_credentials_secret
     assert "user" not in data
     assert "password" not in data
 
@@ -110,7 +112,7 @@ def test_wazuh_api_relation_data_to_relation_data():
     """
     relation_data = wazuh_api.WazuhApiRelationData(
         endpoint=SAMPLE_RELATION_DATA["endpoint"],
-        secret_user=SAMPLE_RELATION_DATA["secret_user"],
+        user_credentials_secret=SAMPLE_RELATION_DATA["user_credentials_secret"],
         user="wazuh-wui",
         password=secrets.token_hex(),
     )
@@ -131,13 +133,13 @@ def test_requirer_charm_with_valid_relation_data_emits_event():
     password = secrets.token_hex()
     secret_id = harness.add_user_secret({"user": "wazuh-wui", "password": password})
     harness.grant_secret(secret_id, "wazuh-api-consumer")
-    SAMPLE_RELATION_DATA["secret_user"] = secret_id
+    SAMPLE_RELATION_DATA["user_credentials_secret"] = secret_id
     harness.add_relation("wazuh-api", "wazuh-api-provider", app_data=SAMPLE_RELATION_DATA)
     relation_data = harness.charm.wazuh_api.get_relation_data()
 
     assert relation_data
     assert str(relation_data.endpoint) == SAMPLE_RELATION_DATA["endpoint"]
-    assert relation_data.secret_user == SAMPLE_RELATION_DATA["secret_user"]
+    assert relation_data.user_credentials_secret == SAMPLE_RELATION_DATA["user_credentials_secret"]
     assert relation_data.user == "wazuh-wui"
     assert relation_data.password == password
 

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -11,6 +11,7 @@ import pytest
 from ops.testing import Harness
 
 import traefik_route_observer
+import wazuh
 
 REQUIRER_METADATA = """
 name: observer-charm
@@ -98,7 +99,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                     },
                     "juju-testing-observer-charm-service-api-tcp": {
                         "loadBalancer": {
-                            "servers": [{"address": "wazuh-server.local:55000"}],
+                            "servers": [{"address": f"wazuh-server.local:{wazuh.API_PORT}"}],
                             "terminationDelay": -1,
                         }
                     },
@@ -110,7 +111,7 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                 "syslog-tcp": {"address": ":6514"},
                 "conn-tcp": {"address": ":1514"},
                 "enrole-tcp": {"address": ":1515"},
-                "api-tcp": {"address": ":55000"},
+                "api-tcp": {"address": f":{wazuh.API_PORT}"},
             }
         },
     )

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
     pytest
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} \
+    coverage run --source={[vars]src_path},{[vars]lib_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native --log-cli-level=DEBUG -s {posargs}
     coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist = lint, unit, static, coverage-report
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path}
+lib_path = {toxinidir}/lib/charms/wazuh_server
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
 setenv =
@@ -64,7 +64,7 @@ commands =
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path} --ignore=W503
+    pflake8 {[vars]all_path} --ignore=W503,E402
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
     mypy {[vars]all_path}


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add the requirer side of the new wazuh-api relation so that the wazuh server provides a mechanism to share the connection details of the API with other charms
This will be used initially to configure the wazuh dashboard
### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
