### PR TITLE
Remove collision with local credentials

### DIFF
--- a/lib/charms/wazuh_server/v0/wazuh_api.py
+++ b/lib/charms/wazuh_server/v0/wazuh_api.py
@@ -82,7 +82,7 @@ from pydantic import AnyHttpUrl, BaseModel, ValidationError
 logger = logging.getLogger(__name__)
 
 RELATION_NAME = "wazuh-api"
-WAZUH_API_KEY_SECRET_LABEL = "wazuh-api-credentials"
+WAZUH_API_KEY_SECRET_LABEL = "wazuh-api-remote-credentials"
 
 
 class SecretError(Exception):


### PR DESCRIPTION
The previous label was the same as the one used to store local credentials.
With this PR we split both to avoid overwriting wazuh's credentials.