### PR TITLE
Update how to configure documentation URL format

### DIFF
--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -8,7 +8,7 @@ To customize the configuration of your charmed Wazuh, use the `custom-config-rep
 
 The URL of this repository should be in the form `git+ssh://youruser@yourepot@yourref` where:
 
-- `youruser` is the SSH user to checkout your repository.
+- `youruser` is the SSH user to check out your repository.
 - `yourrepo` is the address of your repository.
 - `yourref` is a Git reference, typically a tag, to specify the version you want to deploy.
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Update the how to configure documentation to have the proper repository URL format

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
