### PR TITLE
Delete configuration files if not present in the repository

### DIFF
--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -27,7 +27,7 @@ juju grant-secret my-custom-config-ssh-key wazuh-server
 
 Your repository should mimic the layout of the Wazuh server configuration with a `var/ossec` folder.
 
-All files in the following sub-folders will be copied to the Wazuh server. Files matching the patterns but not present in the repository will be removed:
+All files in the following sub-folders will be mirrored to the Wazuh server (new files will be copied to the server, deleted files will be removed from the server):
 
 - `etc/*.conf`
 - `etc/decoders/` recursively

--- a/docs/how-to/configure.md
+++ b/docs/how-to/configure.md
@@ -27,7 +27,7 @@ juju grant-secret my-custom-config-ssh-key wazuh-server
 
 Your repository should mimic the layout of the Wazuh server configuration with a `var/ossec` folder.
 
-All files in the following sub-folders will be copied to the Wazuh server:
+All files in the following sub-folders will be copied to the Wazuh server. Files matching the patterns but not present in the repository will be removed:
 
 - `etc/*.conf`
 - `etc/decoders/` recursively

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -328,6 +328,7 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "-a",
                 "--chown",
                 "wazuh:wazuh",
+                "--delete",
                 "--include='*/'",
                 "--include='etc/*.conf'",
                 "--include='etc/decoders/***'",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Change the way files are copied from the customization repository to the deployment. Going forward, configuration files not present in the repository in the  will be removed

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
