### PR TITLE
Fix ossec configuration

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -128,8 +128,6 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals
         _generate_cluster_snippet(node_name, node_type, master_address, cluster_key)
     )
     elements[0].append(new_cluster)
-    node = etree.fromstring(_generate_syslog_snippet())
-    elements[0].append(node)
 
     content = b"".join([etree.tostring(element, pretty_print=True) for element in elements])
     container.push(OSSEC_CONF_PATH, content, encoding="utf-8")
@@ -405,20 +403,6 @@ def _generate_cluster_snippet(
         </cluster>
 
     """
-
-
-def _generate_syslog_snippet() -> str:
-    """Generate the snippet for syslog configuration.
-
-    Returns: the list of nodes for the Wazuh configuration.
-    """
-    return """
-        <localfile>
-            <log_format>syslog</log_format>
-            <location>/var/ossec/logs/archives/archives.log</location>
-        </localfile>
-
-        """
 
 
 def authenticate_user(username: str, password: str) -> str:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Remove the 
```
<localfile>
            <log_format>syslog</log_format>
            <location>/var/ossec/logs/archives/archives.log</location>
</localfile>
```
block from the configuration

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
