### PR TITLE
Add grafana agent name outputs to TF plan

### DIFF
--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -60,7 +60,7 @@ output "wazuh_dashboard_name" {
   value       = module.wazuh_dashboard.app_name
 }
 
-output "wazuh_indexer_grafana_agent_name" {
+output "wazuh_dashboard_grafana_agent_name" {
   description = "Name of the deployed Grafana agent for the Wazuh dashboard application."
   value       = module.wazuh_dashboard.grafana_agent_app_name
 }

--- a/terraform/product/outputs.tf
+++ b/terraform/product/outputs.tf
@@ -42,6 +42,11 @@ output "wazuh_indexer_name" {
   value       = module.wazuh_indexer.app_name
 }
 
+output "wazuh_indexer_grafana_agent_name" {
+  description = "Name of the deployed Grafana agent for the Wazuh indexer application."
+  value       = module.wazuh_indexer.grafana_agent_app_name
+}
+
 output "wazuh_indexer_grafana_agent_requires" {
   value = module.wazuh_indexer.grafana_agent_requires
 }
@@ -53,6 +58,11 @@ output "wazuh_indexer_grafana_agent_provides" {
 output "wazuh_dashboard_name" {
   description = "Name of the deployed Wazuh dashboard application."
   value       = module.wazuh_dashboard.app_name
+}
+
+output "wazuh_indexer_grafana_agent_name" {
+  description = "Name of the deployed Grafana agent for the Wazuh dashboard application."
+  value       = module.wazuh_dashboard.grafana_agent_app_name
 }
 
 output "wazuh_dashboard_grafana_agent_requires" {


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add grafana agent name outputs to TF plan

### Rationale

<!-- The reason the change is needed -->
So that agents can be configured and integrated with other charms from caller modules

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
