### PR TITLE
Wazuh integration with OpenCTI

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -107,7 +107,7 @@ requires:
     interface: opensearch_client
     limit: 1
   opencti-connector:
-    interface: opencti-connectors
+    interface: opencti-connector
     limit: 1
     required: false
 config:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -106,6 +106,10 @@ requires:
   opensearch-client:
     interface: opensearch_client
     limit: 1
+  opencti-connector:
+    interface: opencti-connectors
+    limit: 1
+    required: false
 config:
   options:
     agent-password:
@@ -122,7 +126,7 @@ config:
     custom-config-ssh-key:
       type: secret
       description: >
-        The Juju secret ID corresponding to the private key for SSH authentication.
+        The Juju secret ID corresponding to the private key for SSH authentication to the git repository.
         The secret should contain a single key, "value", which maps to the actual SSH key. 
         To create the secret, run the following command: 
         `juju add-secret my-custom-config-ssh-key value=<ssh-key> && juju grant-secret my-custom-config-ssh-key wazuh-server`,

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -96,6 +96,10 @@ provides:
     interface: prometheus_scrape
   wazuh-api:
     interface: wazuh_api_client
+  opencti-connector:
+    interface: opencti_connector
+    limit: 1
+    required: false
 requires:
   certificates:
     interface: tls-certificates
@@ -109,10 +113,6 @@ requires:
   opensearch-client:
     interface: opensearch_client
     limit: 1
-  opencti-connector:
-    interface: opencti-connector
-    limit: 1
-    required: false
 config:
   options:
     agent-password:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-06-06
+
+### Added
+
+- OpenCTI integration with Wazuh server.
+
 ## 2025-03-18
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,7 @@ Each revision is versioned by the date of the revision.
 
 ### Updated
 
-- `CODEOWNERS` file to only have the `/docs` directory monitored by the TAs.
+- `CODEOWNERS` file to only have the `/docs` directory monitored by the technical authors.
 
 ### Added
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from ops import pebble
 
 import certificates_observer
 import observability
+import opencti_connector_observer
 import opensearch_observer
 import state
 import traefik_route_observer
@@ -55,6 +56,7 @@ class WazuhServerCharm(CharmBaseWithState):
         self.opensearch = opensearch_observer.OpenSearchObserver(self)
         self._observability = observability.Observability(self)
         self._wazuh_api = wazuh_api.WazuhApiProvides(self)
+        self._opencti_observer = opencti_connector_observer.OpenCTIObserver(self)
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.wazuh_server_pebble_ready, self.reconcile)
@@ -111,10 +113,15 @@ class WazuhServerCharm(CharmBaseWithState):
             opensearch_relation_data = (
                 opensearch_relation.data[opensearch_relation.app] if opensearch_relation else {}
             )
+            opencti_relation = self.model.get_relation(opencti_connector_observer.RELATION_NAME)
+            opencti_relation_data = (
+                opencti_relation.data[opencti_relation.app] if opencti_relation else {}
+            )
             certificates = self.certificates.certificates.get_provider_certificates()
             return State.from_charm(
                 self,
                 opensearch_relation_data,
+                opencti_relation_data,
                 certificates,
                 self.certificates.get_csr().decode("utf-8"),
             )
@@ -193,6 +200,8 @@ class WazuhServerCharm(CharmBaseWithState):
             self.master_fqdn,
             self.unit.name,
             self.state.cluster_key,
+            self.state.opencti_url,
+            self.state.opencti_token,
         )
 
     # It doesn't make sense to split the logic further

--- a/src/opencti_connector_observer.py
+++ b/src/opencti_connector_observer.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""The Certificates relation observer."""
+
+import logging
+
+import ops
+from ops.framework import Object
+
+from state import CharmBaseWithState
+
+logger = logging.getLogger(__name__)
+
+RELATION_NAME = "opencti-connector"
+CONNECTOR_TYPE = "EXTERNAL_IMPORT"
+
+
+class OpenCTIObserver(Object):
+    """The OpenCTI relation observer."""
+
+    def __init__(self, charm: CharmBaseWithState):
+        """Initialize the observer and register event handlers.
+
+        Args:
+            charm: The parent charm to attach the observer to.
+        """
+        super().__init__(charm, RELATION_NAME)
+        self._charm = charm
+        self.framework.observe(
+            self.on.opencti_connector_relation_joined, self._on_opencti_relation_joined
+        )
+        self.framework.observe(
+            self._charm.on.opencti_connector_relation_changed, self._charm.reconcile
+        )
+
+    def _on_opencti_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
+        """Handle OpenCTI relation joined event."""
+        if not self._charm.unit.is_leader():
+            return
+        relation = event.relation
+        app_data = relation.data[self._charm.app]
+        app_data["connector_charm_name"] = self._charm.meta.name
+        app_data["connector_type"] = CONNECTOR_TYPE

--- a/src/opencti_connector_observer.py
+++ b/src/opencti_connector_observer.py
@@ -35,7 +35,11 @@ class OpenCTIObserver(Object):
         )
 
     def _on_opencti_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
-        """Handle OpenCTI relation joined event."""
+        """Handle OpenCTI relation joined event.
+
+        Args:
+            event: The relation joined event.
+        """
         if not self._charm.unit.is_leader():
             return
         relation = event.relation

--- a/src/opencti_connector_observer.py
+++ b/src/opencti_connector_observer.py
@@ -28,7 +28,7 @@ class OpenCTIObserver(Object):
         super().__init__(charm, RELATION_NAME)
         self._charm = charm
         self.framework.observe(
-            self.on.opencti_connector_relation_joined, self._on_opencti_relation_joined
+            self._charm.on.opencti_connector_relation_joined, self._on_opencti_relation_joined
         )
         self.framework.observe(
             self._charm.on.opencti_connector_relation_changed, self._charm.reconcile

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -63,6 +63,10 @@ class WazuhAuthenticationError(Exception):
     """Wazuh authentication errors."""
 
 
+class WazuhConfigurationError(WazuhInstallationError):
+    """Wazuh configuration errors."""
+
+
 class NodeType(Enum):
     """Enum for the Wazuh node types.
 
@@ -91,12 +95,14 @@ def _update_filebeat_configuration(container: ops.Container, ip_ports: list[str]
 
 
 # Won't sacrify cohesion and readability to make pylint happier
-def _update_wazuh_configuration(  # pylint: disable=too-many-locals
+def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-arguments
     container: ops.Container,
     ip_ports: list[str],
     master_address: str,
     unit_name: str,
     cluster_key: str,
+    opencti_token: str | None = None,
+    opencti_url: str | None = None,
 ) -> None:
     """Update Wazuh configuration.
 
@@ -106,11 +112,18 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals
         master_address: the master unit addresses.
         unit_name: the unit's name.
         cluster_key: the Wazuh key for the cluster nodes.
+        opencti_token: OpenCTI API token.
+        opencti_url: OpenCTI URL.
+
+    Raises:
+        WazuhConfigurationError: if the configuration is invalid or missing required elements.
     """
     ossec_config = container.pull(OSSEC_CONF_PATH, encoding="utf-8").read()
     # Enclose the config file in an element since it might have repeated roots
     ossec_config_tree = etree.fromstring(f"<root>{ossec_config}</root>")
     hosts = ossec_config_tree.xpath("/root/ossec_config/indexer/hosts")
+    if not hosts:
+        raise WazuhConfigurationError("No indexer hosts found in the configuration.")
     hosts[0].clear()
     for ip_port in ip_ports:
         new_host = etree.Element("host")
@@ -129,16 +142,40 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals
     )
     elements[0].append(new_cluster)
 
+    integration = ossec_config_tree.find(".//integration[name='custom-opencti']")
+    if integration is not None:
+        if not opencti_token or not opencti_url:
+            raise WazuhConfigurationError(
+                "Missing OpenCTI token or url for custom-opencti integration."
+                "Ensure OpenCTI is integrated with Wazuh."
+            )
+
+        api_key = integration.find("api_key")
+        if api_key is None:
+            raise WazuhConfigurationError(
+                "Missing API key in the custom-opencti integration configuration section."
+            )
+        api_key.text = opencti_token
+
+        hook_url = integration.find("hook_url")
+        if hook_url is None:
+            raise WazuhConfigurationError(
+                "Missing hook URL key in custom-opencti integration configuration section."
+            )
+        hook_url.text = f"{opencti_url}/graphql"
+
     content = b"".join([etree.tostring(element, pretty_print=True) for element in elements])
     container.push(OSSEC_CONF_PATH, content, encoding="utf-8")
 
 
-def update_configuration(
+def update_configuration(  # pylint: disable=too-many-arguments
     container: ops.Container,
     indexer_ips: list[str],
     master_address: str,
     unit_name: str,
     cluster_key: str,
+    opencti_url: str | None = None,
+    opencti_token: str | None = None,
 ) -> None:
     """Update the workload configuration.
 
@@ -148,10 +185,14 @@ def update_configuration(
         master_address: the master unit addresses.
         unit_name: the unit's name.
         cluster_key: the Wazuh key for the cluster nodes.
+        opencti_url: the URL used for OpenCTI APIs.
+        opencti_token: OpenCTI API token.
     """
     ip_ports = [f"{ip}" for ip in indexer_ips]
     _update_filebeat_configuration(container, ip_ports)
-    _update_wazuh_configuration(container, ip_ports, master_address, unit_name, cluster_key)
+    _update_wazuh_configuration(
+        container, ip_ports, master_address, unit_name, cluster_key, opencti_token, opencti_url
+    )
 
 
 def install_certificates(  # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -101,6 +101,7 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
     master_address: str,
     unit_name: str,
     cluster_key: str,
+    *,
     opencti_token: str | None = None,
     opencti_url: str | None = None,
 ) -> None:
@@ -168,7 +169,7 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
     container.push(OSSEC_CONF_PATH, content, encoding="utf-8")
 
 
-def update_configuration(  # pylint: disable=too-many-arguments
+def update_configuration(  # pylint: disable=too-many-arguments, too-many-positional-arguments
     container: ops.Container,
     indexer_ips: list[str],
     master_address: str,
@@ -191,7 +192,13 @@ def update_configuration(  # pylint: disable=too-many-arguments
     ip_ports = [f"{ip}" for ip in indexer_ips]
     _update_filebeat_configuration(container, ip_ports)
     _update_wazuh_configuration(
-        container, ip_ports, master_address, unit_name, cluster_key, opencti_token, opencti_url
+        container,
+        ip_ports,
+        master_address,
+        unit_name,
+        cluster_key,
+        opencti_token=opencti_token,
+        opencti_url=opencti_url,
     )
 
 

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -143,25 +143,25 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
     )
     elements[0].append(new_cluster)
 
-    integration = ossec_config_tree.find(".//integration[name='custom-opencti']")
-    if integration is not None:
-        if not opencti_token or not opencti_url:
-            raise WazuhConfigurationError(
-                "Missing OpenCTI token or url for custom-opencti integration."
-                "Ensure OpenCTI is integrated with Wazuh."
-            )
+    integrations = ossec_config_tree.xpath(".//integration[starts-with(name, 'custom-opencti-')]")
+    if integrations and (not opencti_token or not opencti_url):
+        raise WazuhConfigurationError(
+            "Missing OpenCTI token or url for custom-opencti integrations. "
+            "Ensure OpenCTI is integrated with Wazuh."
+        )
 
+    for integration in integrations:
         api_key = integration.find("api_key")
         if api_key is None:
             raise WazuhConfigurationError(
-                "Missing API key in the custom-opencti integration configuration section."
+                f"Missing API key in {etree.tostring(integration, pretty_print=True).decode()}."
             )
         api_key.text = opencti_token
 
         hook_url = integration.find("hook_url")
         if hook_url is None:
             raise WazuhConfigurationError(
-                "Missing hook URL key in custom-opencti integration configuration section."
+                f"Missing hook_url in {etree.tostring(integration, pretty_print=True).decode()}."
             )
         hook_url.text = f"{opencti_url}/graphql"
 

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# This Python script is designed to be loaded into any-charm. Some lint checks do not apply
+# pylint: disable=import-error,too-few-public-methods
+
+"""This code snippet is used to be loaded into any-charm which is used for integration tests."""
+import jwt
+from any_charm_base import AnyCharmBase
+
+
+class AnyCharm(AnyCharmBase):
+    """Any charm that requires an OpenCTI connector relation."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the AnyCharm class.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+            kwargs: Variable list of positional keyword arguments passed to the parent constructor.
+        """
+        super().__init__(*args, **kwargs)
+        self.framework.observe(self.on.require_opencti_connector_relation_joined, self._reconcile)
+        self.framework.observe(self.on.require_opencti_connector_relation_changed, self._reconcile)
+
+    def _reconcile(self, event) -> None:
+        """Provide sample OpenCTI URL and token to the relation.
+
+        Args:
+            event: The event that triggered the method.
+        """
+        relation = event.relation
+        relation.data[self.app][
+            "opencti_url"
+        ] = f"http://{self.app.name}-endpoints.{self.model.name}.svc:8080"
+        sample_token = jwt.encode({"sub": "sample-user"}, "sample-key", algorithm="HS256")
+        opencti_token_id = relation.data[self.app].get("opencti_token")
+        if not opencti_token_id:
+            secret = self.app.add_secret(content={"token": sample_token})
+            secret.grant(relation)
+            relation.data[self.app]["opencti_token"] = str(secret.id)
+        else:
+            secret = self.model.get_secret(id=opencti_token_id)
+            if secret.get_content(refresh=True)["token"] != sample_token:
+                secret.set_content({"token": sample_token})

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -261,8 +261,8 @@ async def opencti_any_charm_fixture(
                     relation.data[self.app]["opencti_token"] = str(secret.id)
                 else:
                     secret = self.model.get_secret(id=opencti_token_id)
-                    if secret.get_content(refresh=True)["token"] != api_token:
-                        secret.set_content({"token": api_token})
+                    if secret.get_content(refresh=True)["token"] != sample_token:
+                        secret.set_content({"token": sample_token})
         """
         ),
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -246,9 +246,9 @@ async def opencti_any_charm_fixture(
         class AnyCharm(AnyCharmBase):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self.framework.observe(self.on.opencti_connector_relation_joined, self._reconcile)
-                self.framework.observe(self.on.opencti_connector_relation_changed, self._reconcile)
-            def _reconcile(self, event: ops.EventBase) -> None:
+                self.framework.observe(self.on.provide_opencti_connector_relation_joined, self._reconcile)
+                self.framework.observe(self.on.provide_opencti_connector_relation_changed, self._reconcile)
+            def _reconcile(self, event) -> None:
                 relation = event.relation
                 relation.data[self.app][
                     "opencti_url"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,6 +15,7 @@ import requests
 import yaml
 from juju.application import Application
 from juju.model import Model
+from juju.relation import Relation
 
 import state
 import wazuh
@@ -129,3 +130,20 @@ async def test_rsyslog_client_cn(application: Application, valid_cn: bool, expec
     found = await found_in_logs(needle)
 
     assert found is expect_logs, f"Found logs={found}, while expected logs={expect_logs}"
+
+
+async def test_opencti_integration(any_opencti: Application, application: Application):
+    """
+    Arrange: a working Wazuh deployment integrated with OpenCTI any-charm.
+    Act: do nothing.
+    Assert: the opencti-connector relation is established and the required data is present.
+    """
+    assert any_opencti
+    assert application
+
+    relation: Relation = await application.relations["opencti-connector"]
+
+    assert relation
+    app_data = relation.data[application]
+    for key in ["connector_charm_name", "connector_type", "opencti_url", "opencti_token"]:
+        assert key in app_data, f"Missing key in app data: {key}"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -172,6 +172,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
+        None,
+        None,
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
     wazuh_configure_agent_password_mock.assert_called_with(
@@ -282,6 +284,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
+        None,
+        None,
     )
     get_version_mock.assert_called_with(container)
     assert harness.model.unit.status.name == ops.ActiveStatus().name

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -121,6 +121,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
     password = secrets.token_hex()
     agent_password = secrets.token_hex()
     cluster_key = secrets.token_hex(16)
+    opencti_token = secrets.token_hex(16)
+    opencti_url = "https://opencti.example.com"
     state_from_charm_mock.return_value = State(
         agent_password=agent_password,
         api_credentials=api_credentials,
@@ -132,6 +134,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         filebeat_password=password,
         wazuh_config=wazuh_config,
         custom_config_ssh_key="somekey",
+        opencti_token=opencti_token,
+        opencti_url=opencti_url,
     )
     get_version_mock.return_value = "v4.9.2"
     filebeat_csr_mock.return_value = b""
@@ -172,8 +176,8 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         "wazuh-server-0.wazuh-server-endpoints",
         "wazuh-server/0",
         cluster_key,
-        None,
-        None,
+        opencti_url,
+        opencti_token,
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
     wazuh_configure_agent_password_mock.assert_called_with(

--- a/tests/unit/test_opencti_observer.py
+++ b/tests/unit/test_opencti_observer.py
@@ -10,9 +10,9 @@ from opencti_connector_observer import CONNECTOR_TYPE, RELATION_NAME, OpenCTIObs
 
 REQUIRER_METADATA = """
 name: observer-charm
-requires:
+provides:
   opencti-connector:
-    interface: opencti-connector
+    interface: opencti_connector
 """
 
 
@@ -43,8 +43,8 @@ def test_relation_joined_sets_data() -> None:
     harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
     harness.begin_with_initial_hooks()
     harness.set_leader(True)
-    rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
-    harness.add_relation_unit(rel_id, "opencti-connector/0")
+    rel_id = harness.add_relation(RELATION_NAME, "opencti")
+    harness.add_relation_unit(rel_id, "opencti/0")
 
     app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert app_data["connector_charm_name"] == harness.charm.meta.name
@@ -60,8 +60,8 @@ def test_relation_joined_does_nothing_if_not_leader() -> None:
     harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
     harness.begin_with_initial_hooks()
     harness.set_leader(False)
-    rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
-    harness.add_relation_unit(rel_id, "opencti-connector/0")
+    rel_id = harness.add_relation(RELATION_NAME, "opencti")
+    harness.add_relation_unit(rel_id, "opencti/0")
 
     app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
     assert "connector_charm_name" not in app_data
@@ -76,7 +76,7 @@ def test_relation_changed_calls_reconcile() -> None:
     """
     harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
     harness.begin_with_initial_hooks()
-    rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
-    harness.update_relation_data(rel_id, "opencti-connector", {"token": "abcd1234"})
+    rel_id = harness.add_relation(RELATION_NAME, "opencti")
+    harness.update_relation_data(rel_id, "opencti", {"token": "abcd1234"})
 
     assert harness.charm.count == 1

--- a/tests/unit/test_opencti_observer.py
+++ b/tests/unit/test_opencti_observer.py
@@ -12,7 +12,7 @@ REQUIRER_METADATA = """
 name: observer-charm
 requires:
   opencti-connector:
-    interface: opencti-connectors
+    interface: opencti-connector
 """
 
 

--- a/tests/unit/test_opencti_observer.py
+++ b/tests/unit/test_opencti_observer.py
@@ -77,6 +77,6 @@ def test_relation_changed_calls_reconcile() -> None:
     harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
     harness.begin_with_initial_hooks()
     rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
-    harness.update_relation_data(rel_id, "opencti-connector", {"dummy": "value"})
+    harness.update_relation_data(rel_id, "opencti-connector", {"token": "abcd1234"})
 
     assert harness.charm.count == 1

--- a/tests/unit/test_opencti_observer.py
+++ b/tests/unit/test_opencti_observer.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""OpenCTI observer unit tests."""
+
+import ops
+from ops.testing import Harness
+
+from opencti_connector_observer import CONNECTOR_TYPE, RELATION_NAME, OpenCTIObserver
+
+REQUIRER_METADATA = """
+name: observer-charm
+requires:
+  opencti-connector:
+    interface: opencti-connectors
+"""
+
+
+class ObservedCharm(ops.CharmBase):
+    """Class for requirer charm testing."""
+
+    def __init__(self, *args):
+        """Construct.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+        """
+        super().__init__(*args)
+        self.observer = OpenCTIObserver(self)
+        self.count = 0
+
+    def reconcile(self, _: ops.HookEvent) -> None:
+        """Reconcile the configuration with charm state."""
+        self.count = self.count + 1
+
+
+def test_relation_joined_sets_data() -> None:
+    """
+    arrange: instantiate a charm implementing the OpenCTI connector relation.
+    act: add a relation and a leader unit to the OpenCTI connector.
+    assert: the relation data is set with the connector charm name and type.
+    """
+    harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
+    harness.begin_with_initial_hooks()
+    harness.set_leader(True)
+    rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
+    harness.add_relation_unit(rel_id, "opencti-connector/0")
+
+    app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert app_data["connector_charm_name"] == harness.charm.meta.name
+    assert app_data["connector_type"] == CONNECTOR_TYPE
+
+
+def test_relation_joined_does_nothing_if_not_leader() -> None:
+    """
+    arrange: instantiate a charm implementing the OpenCTI connector relation.
+    act: add a relation and a non-leader unit to the OpenCTI connector.
+    assert: the relation data is not set.
+    """
+    harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
+    harness.begin_with_initial_hooks()
+    harness.set_leader(False)
+    rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
+    harness.add_relation_unit(rel_id, "opencti-connector/0")
+
+    app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+    assert "connector_charm_name" not in app_data
+    assert "connector_type" not in app_data
+
+
+def test_relation_changed_calls_reconcile() -> None:
+    """
+    arrange: instantiate a charm implementing the OpenCTI connector relation.
+    act: add a relation and update its data.
+    assert: the reconcile method is called once.
+    """
+    harness = Harness(ObservedCharm, meta=REQUIRER_METADATA)
+    harness.begin_with_initial_hooks()
+    rel_id = harness.add_relation(RELATION_NAME, "opencti-connector")
+    harness.update_relation_data(rel_id, "opencti-connector", {"dummy": "value"})
+
+    assert harness.charm.count == 1

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -6,6 +6,7 @@
 import datetime
 import secrets
 import unittest
+import unittest.mock
 
 import charms.tls_certificates_interface.v3.tls_certificates as certificates
 import ops
@@ -66,13 +67,14 @@ def test_state_without_proxy():
     secret_id = f"secret:{secrets.token_hex()}"
     mock_charm.config = {"wazuh-api-credentials": secret_id, "logs-ca-cert": "fakeca"}
     endpoints = ["10.0.0.1", "10.0.0.2"]
-    username = "user1"
-    password = secrets.token_hex()
+    secret_id = f"secret:{secrets.token_hex()}"
     opensearch_relation_data = {
         "endpoints": ",".join(endpoints),
-        "secret-user": f"secret:{secrets.token_hex()}",
+        "secret-user": secret_id,
     }
-    secret_id = f"secret:{secrets.token_hex()}"
+
+    username = "user1"
+    password = secrets.token_hex()
     value = secrets.token_hex(16)
     mock_charm.model.get_secret(id=secret_id).get_content.return_value = {
         "username": username,
@@ -690,3 +692,62 @@ def test_state_without_logs_ca_cert():
     assert str(exc.value) == str(
         state.RecoverableStateError("Invalid charm configuration logs_ca_cert")
     )
+
+
+def test_state_with_opencti_relation_data():
+    """
+    arrange: given valid OpenCTI relation data.
+    act: when state is initialized through from_charm method.
+    assert: the state contains the OpenCTI relation data.
+    """
+    mock_charm = unittest.mock.MagicMock(spec=ops.CharmBase)
+    secret_id = f"secret:{secrets.token_hex()}"
+    mock_charm.config = {"wazuh-api-credentials": secret_id, "logs-ca-cert": "fakeca"}
+    endpoints = ["10.0.0.1", "10.0.0.2"]
+    secret_id = f"secret:{secrets.token_hex()}"
+    opensearch_relation_data = {
+        "endpoints": ",".join(endpoints),
+        "secret-user": secret_id,
+    }
+
+    username = "user1"
+    password = secrets.token_hex()
+    value = secrets.token_hex(16)
+    opencti_token = secrets.token_hex()
+    mock_charm.model.get_secret(id=secret_id).get_content.return_value = {
+        "username": username,
+        "password": password,
+        "value": value,
+        "token": opencti_token,
+    }
+
+    provider_certificates = [
+        certificates.ProviderCertificate(
+            relation_id="certificates-provider/1",
+            application_name="application",
+            csr="1",
+            certificate="certificate",
+            ca="root_ca",
+            chain=[],
+            revoked=False,
+            expiry_time=datetime.datetime(day=1, month=1, year=datetime.MAXYEAR),
+        )
+    ]
+
+    opencti_url = "http://opencti.local"
+    opencti_token_secret_id = f"secret:{secrets.token_hex()}"
+    opencti_relation_data = {
+        "opencti_url": opencti_url,
+        "opencti_token": opencti_token_secret_id,
+    }
+
+    charm_state = state.State.from_charm(
+        mock_charm,
+        opensearch_relation_data,
+        opencti_relation_data,
+        provider_certificates,
+        "1",
+    )
+
+    assert charm_state.opencti_url == opencti_url
+    assert charm_state.opencti_token == opencti_token

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -48,11 +48,12 @@ def test_state_invalid_opensearch_relation_data(opensearch_relation_data):
         state.State.from_charm(
             mock_charm,
             opensearch_relation_data,
+            {},
             provider_certificates,
             "1",
         )
     with pytest.raises(state.RecoverableStateError):
-        state.State.from_charm(mock_charm, opensearch_relation_data, [], "1")
+        state.State.from_charm(mock_charm, opensearch_relation_data, {}, [], "1")
 
 
 def test_state_without_proxy():
@@ -94,6 +95,7 @@ def test_state_without_proxy():
     charm_state = state.State.from_charm(
         mock_charm,
         opensearch_relation_data,
+        {},
         provider_certificates,
         "1",
     )
@@ -156,6 +158,7 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
     charm_state = state.State.from_charm(
         mock_charm,
         opensearch_relation_data,
+        {},
         provider_certificates,
         "1",
     )
@@ -215,6 +218,7 @@ def test_proxyconfig_invalid(monkeypatch: pytest.MonkeyPatch):
     charm_state = state.State.from_charm(
         mock_charm,
         opensearch_relation_data,
+        {},
         provider_certificates,
         "1",
     )
@@ -270,6 +274,7 @@ def test_state_when_repository_secret_not_found(monkeypatch: pytest.MonkeyPatch)
         state.State.from_charm(
             mock_charm,
             opensearch_relation_data,
+            {},
             provider_certificates,
             "1",
         )
@@ -322,6 +327,7 @@ def test_state_when_agent_password_secret_not_found(monkeypatch: pytest.MonkeyPa
         state.State.from_charm(
             mock_charm,
             opensearch_relation_data,
+            {},
             provider_certificates,
             "1",
         )
@@ -376,6 +382,7 @@ def test_state_when_repository_secret_invalid(monkeypatch: pytest.MonkeyPatch):
         state.State.from_charm(
             mock_charm,
             opensearch_relation_data,
+            {},
             provider_certificates,
             "1",
         )
@@ -428,6 +435,7 @@ def test_state_when_agent_secret_invalid(monkeypatch: pytest.MonkeyPatch):
         state.State.from_charm(
             mock_charm,
             opensearch_relation_data,
+            {},
             provider_certificates,
             "1",
         )
@@ -485,6 +493,7 @@ def test_state_when_repository_secret_valid(monkeypatch: pytest.MonkeyPatch):
     charm_state = state.State.from_charm(
         mock_charm,
         opensearch_relation_data,
+        {},
         provider_certificates,
         "1",
     )
@@ -550,6 +559,7 @@ def test_state_when_agent_password_secret_valid(monkeypatch: pytest.MonkeyPatch)
     charm_state = state.State.from_charm(
         mock_charm,
         opensearch_relation_data,
+        {},
         provider_certificates,
         "1",
     )
@@ -613,6 +623,7 @@ def test_state_when_logs_ca_cert_valid(monkeypatch: pytest.MonkeyPatch):
     charm_state = state.State.from_charm(
         mock_charm,
         opensearch_relation_data,
+        {},
         provider_certificates,
         "1",
     )
@@ -671,6 +682,7 @@ def test_state_without_logs_ca_cert():
         state.State.from_charm(
             mock_charm,
             opensearch_relation_data,
+            {},
             provider_certificates,
             "1",
         )

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ deps =
     mypy
     pep8-naming
     pydocstyle>=2.10
+    PyJWT
     pylint
     pyproject-flake8<6.0.0
     pytest
@@ -102,6 +103,7 @@ commands =
 description = Run integration tests
 deps =
     juju
+    PyJWT
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Added integration with openCTI to fetch `opencti_url` and `opencti_token` and update `ossec.conf`

**NOTE TO REVIEWERS**: Security team has agreed that the format of the custom-integration names in `ossec.conf` will begin with `custom-opencti-*`. This way:
- If they add more opencti custom integration scripts later, no code changes would be required on wazuh-server side.
- If they have more custom integration scripts in the future that aren't for OpenCTI, this code wouldn't accidentally replace the url and API key for those scripts.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
