### PR TITLE
Doc/contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,20 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working [development setup](https://documentation.ubuntu.com/juju/latest/howto/manage-your-deployment/manage-your-deployment-environment/index.html).
 
-You can create an environment for development with `tox`:
+## Developing
 
-```shell
-tox devenv -e integration
-source venv/bin/activate
-```
-
-## Generating src docs for every commit
-
-Run the following command:
+The code for this charm can be downloaded as follows:
 
 ```bash
-echo -e "tox -e src-docs\ngit add src-docs\n" >> .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+git clone https://github.com/canonical/wazuh-server-operator
+```
+
+You can use the environments created by `tox` for development:
+
+```shell
+tox --notest -e unit
+source .tox/unit/bin/activate
 ```
 
 ## Testing
@@ -24,14 +23,22 @@ This project uses `tox` for managing test environments. There are some pre-confi
 that can be used for linting and formatting code when you're preparing contributions to the charm:
 
 ```shell
-tox run -e format        # update your code according to linting rules
-tox run -e lint          # code style
-tox run -e unit          # unit tests
-tox run -e integration   # integration tests
-tox                      # runs 'format', 'lint', and 'unit' environments
+tox run -e fmt        # update your code according to linting rules
+tox run -e lint       # code style
+tox run -e static     # other checks such as `bandit` for security issues.
+tox run -e unit       # unit tests
+tox                   # runs 'format', 'lint', 'static' and 'unit' environments
 ```
 
-## Build the charm
+### Integration tests
+
+To run the integration tests, you need to:
+
+- Build the charm.
+- Build the rock.
+- Add the rock to the Kubernetes registry.
+
+#### Build charm
 
 Build the charm in this git repository using:
 
@@ -39,4 +46,64 @@ Build the charm in this git repository using:
 charmcraft pack
 ```
 
-<!-- You may want to include any contribution/style guidelines in this document>
+#### Build rock
+
+Build the rock using:
+
+```shell
+cd rock
+rockcraft pack
+```
+
+#### Add rock to registry
+
+The [Wazuh Server](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml) image needs to be pushed to MicroK8s for the tests to run. It should be tagged as `localhost:32000/wazuh-server:latest` so that Kubernetes knows how to pull them from the MicroK8s repository.
+
+Note that the MicroK8s registry needs to be enabled using `microk8s enable registry`.
+
+To add the image to the registry:
+
+```shell
+    skopeo --insecure-policy copy oci-archive:wazuh_server_1.0_amd64.rock docker-daemon:localhost:32000/wazuh-server:latest
+    docker push localhost:32000/wazuh-server:latest
+```
+
+#### Run the integration tests
+
+You can run the tests with:
+
+```shell
+tox run -e integration -- --charm-file=wazuh-server_ubuntu-22.04-amd64.charm --wazuh-server-image 127.0.0.1:5000/wazuh-server:latest
+```
+
+By default, this will create 3 `wazuh-indexer` nodes. This should be fine with 32 GB of RAM. If you have less, you can run a single node indexer with:
+
+```shell
+tox run -e integration -- --charm-file=wazuh-server_ubuntu-22.04-amd64.charm --wazuh-server-image 127.0.0.1:5000/wazuh-server:latest --single-node-indexer
+```
+
+To get faster test results, you may want to reuse your integration environments. To do so, you can initially run:
+
+```shell
+tox run -e integration -- --charm-file=wazuh-server_ubuntu-22.04-amd64.charm --wazuh-server-image 127.0.0.1:5000/wazuh-server:latest --single-node-indexer --model test-wazuh --keep-models
+```
+
+And then use the following command for the next runs:
+
+```shell
+tox run -e integration -- --charm-file=wazuh-server_ubuntu-22.04-amd64.charm --wazuh-server-image 127.0.0.1:5000/wazuh-server:latest --single-node-indexer --model test-wazuh --keep-models --no-deploy
+```
+
+### Deploy
+
+A typical deployment would look like:
+
+```bash
+# Create a model
+juju add-model wazuh-server-dev
+# Enable DEBUG logging
+juju model-config logging-config="<root>=INFO;unit=DEBUG"
+# Deploy the charm (assuming you're on amd64)
+juju deploy ./wazuh_server_ubuntu-22.04-amd64.charm \
+  --resource wazuh-server-image=localhost:32000/wazuh-server:latest
+```

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -1,88 +1,10 @@
 # How to contribute
 
-This document explains the processes and practices recommended for contributing enhancements to the Wazuh Server operator.
+Our documentation is hosted on the [Github](https://discourse.charmhub.io/t/wazuh-server-documentation-overview/16070) to enable collaboration. Please use the "Help us improve this documentation" links on each documentation page to either directly change something you see that's wrong, ask a question, or make a suggestion about a potential change via the comments section.
 
-## Overview
+Our documentation is also available alongside the [source code on GitHub](https://github.com/canonical/wazuh-server-operator/).
+You may open a pull request with your documentation changes, or you can
+[file a bug](https://github.com/canonical/wazuh-server-operator/issues) to provide constructive feedback or suggestions.
 
-- Generally, before developing enhancements to this charm, you should consider [opening an issue
-  ](https://github.com/canonical/wazuh-server-operator/issues) explaining your use case.
-- If you would like to chat with us about your use-cases or proposed implementation, you can reach
-  us at [Canonical Matrix public channel](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
-  or [Discourse](https://discourse.charmhub.io/).
-- Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
-  will help you a lot when working on new features or bug fixes.
-- All enhancements require review before being merged. Code review typically examines
-  - code quality
-  - test coverage
-  - user experience for Juju operators of this charm
-- Please help us out in ensuring easy to review branches by rebasing your pull request branch onto the `main` branch. This also avoids merge commits and creates a linear Git commit history.
-- Please generate src documentation for every commit. See the section below for more details.
-
-## Developing
-
-The code for this charm can be downloaded as follows:
-
-```bash
-git clone https://github.com/canonical/wazuh-server-operator
-```
-
-You can use the environments created by `tox` for development:
-
-```shell
-tox --notest -e unit
-source .tox/unit/bin/activate
-```
-
-### Testing
-
-Note that the [Wazuh Server](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml) image needs to be built and pushed to MicroK8s for the tests to run. It should be tagged as `localhost:32000/wazuh-server:latest` so that Kubernetes knows how to pull them from the MicroK8s repository. Note that the MicroK8s registry needs to be enabled using `microk8s enable registry`. More details regarding the OCI images below. The following commands can then be used to run the tests:
-
-* `tox`: Runs all of the basic checks (`lint`, `unit`, `static`, and `coverage-report`).
-* `tox -e fmt`: Runs formatting using `black` and `isort`.
-* `tox -e lint`: Runs a range of static code analysis to check the code.
-* `tox -e static`: Runs other checks such as `bandit` for security issues.
-* `tox -e unit`: Runs the unit tests.
-* `tox -e integration`: Runs the integration tests.
-
-### Generating src docs for every commit
-
-Run the following command:
-
-```bash
-echo -e "tox -e src-docs\ngit add src-docs\n" >> .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
-
-## Build charm
-
-Build the charm in this git repository using:
-
-```shell
-charmcraft pack
-```
-For the integration tests (and also to deploy the charm locally), the wazuh-server
-image is required in the Microk8s registry. To enable it:
-
-    microk8s enable registry
-
-The following commands import the images in the Docker daemon and push them into the registry:
-
-    rockcraft pack
-    skopeo --insecure-policy copy oci-archive:wazuh_server_1.0_amd64.rock docker-daemon:localhost:32000/wazuh-server:latest
-    docker push localhost:32000/wazuh-server:latest
-
-### Deploy
-
-```bash
-# Create a model
-juju add-model wazuh-server-dev
-# Enable DEBUG logging
-juju model-config logging-config="<root>=INFO;unit=DEBUG"
-# Deploy the charm (assuming you're on amd64)
-juju deploy ./wazuh_server_ubuntu-22.04-amd64.charm \
-  --resource wazuh-server-image=localhost:32000/wazuh-server:latest
-```
-
-## Canonical Contributor Agreement
-
-Canonical welcomes contributions to the Wazuh Server Operator. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.
+See [CONTRIBUTING.md](https://github.com/canonical/wazuh-server-operator/blob/main/CONTRIBUTING.md)
+for information on contributing to the source code.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -142,7 +142,7 @@ async def opensearch_provider_fixture(
         apps=[app_name], status="active", raise_on_error=False, timeout=1800
     )
     if num_units == 1:
-        await configure_single_node(machine_controller_name)
+        await configure_single_node(f"{machine_controller_name}:admin/{machine_model.name}")
 
     await machine_model.create_offer(f"{application.name}:opensearch-client", application.name)
     yield application


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Align with team standards in terms of "contributing" doc content. Enrich development contribution with examples.

### Rationale

how-to/contribute.md was containing info that should be in CONTRIBUTING.md and some information was missing for someone to start on Wazuh.