### PR TITLE
Mount value to persist data across container restarts

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,7 +77,7 @@ containers:
     resource: wazuh-server-image
     mounts:
       - storage: data
-        location: /tmp/data
+        location: /var/log/collectors
 charm-libs:
   - lib: data_platform_libs.data_interfaces
     version: "0"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -135,3 +135,7 @@ config:
 peers:
   wazuh-peers:
     interface: wazuh-instance
+storage:
+  data:
+    type: filesystem
+    location: /tmp/data

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -75,6 +75,8 @@ assumes:
 containers:
   wazuh-server:
     resource: wazuh-server-image
+    mounts:
+      - storage: data
 charm-libs:
   - lib: data_platform_libs.data_interfaces
     version: "0"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,6 +77,7 @@ containers:
     resource: wazuh-server-image
     mounts:
       - storage: data
+        location: /tmp/data
 charm-libs:
   - lib: data_platform_libs.data_interfaces
     version: "0"
@@ -140,4 +141,3 @@ peers:
 storage:
   data:
     type: filesystem
-    location: /tmp/data

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -45,7 +45,7 @@ The workload that this container is running is defined in the [Wazuh server rock
 
 ### Storage
 
-The Wazuh server charm mounts a [filesystem type storage](https://documentation.ubuntu.com/juju/3.6/reference/storage/#defining-storage) to store the incoming rsyslog logs and any other data that requires persistence across container restarts..
+The Wazuh server charm mounts a [filesystem type storage](https://documentation.ubuntu.com/juju/3.6/reference/storage/#defining-storage) to store the incoming rsyslog logs and any other data that requires persistence across container restarts.
 
 ## Charm code overview
 

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -42,6 +42,11 @@ The Wazuh server listens on ports:
 
 The workload that this container is running is defined in the [Wazuh server rock](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml).
 
+
+### Storage
+
+The Wazuh server charm mounts a [filesystem type storage](https://documentation.ubuntu.com/juju/3.6/reference/storage/#defining-storage) to store the incoming rsyslog logs and any other data that requires persistence across container restarts..
+
 ## Charm code overview
 
 The `src/charm.py` is the default entry point for a charm and has the

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -30,7 +30,7 @@ of charms.
 This is done by publishing a resource to Charmhub as described in the
 [Charmcraft how-to guides](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/#publish-a-charm-on-charmhub).
 
-### Wazuh server
+## Wazuh server
 
 Wazuh server is an application controlled by the `/var/ossec/bin/wazuh-control` script.
 
@@ -43,7 +43,7 @@ The Wazuh server listens on ports:
 The workload that this container is running is defined in the [Wazuh server rock](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml).
 
 
-### Storage
+## Storage
 
 The Wazuh server charm mounts a [filesystem type storage](https://documentation.ubuntu.com/juju/3.6/reference/storage/#defining-storage) to store the incoming rsyslog logs and any other data that requires persistence across container restarts.
 

--- a/rock/wazuh.conf
+++ b/rock/wazuh.conf
@@ -22,4 +22,4 @@ $InputTCPServerRun 6514
 # Storing Messages from a Remote System into a specific File 
 #if $fromhost-ip startswith '<ENDPOINT_IP>' then /var/log/endpoint_logs 
 #& ~
-*.* /tmp/data/rsyslog.log
+*.* /var/log/collectors/rsyslog.log

--- a/rock/wazuh.conf
+++ b/rock/wazuh.conf
@@ -22,4 +22,4 @@ $InputTCPServerRun 6514
 # Storing Messages from a Remote System into a specific File 
 #if $fromhost-ip startswith '<ENDPOINT_IP>' then /var/log/endpoint_logs 
 #& ~
-*.* /tmp/rsyslog.log
+*.* /tmp/data/rsyslog.log

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,7 +114,7 @@ async def found_in_logs(pattern: str) -> bool:
     """
     try:
         sh.juju.ssh(  # pylint: disable=no-member
-            "--container=wazuh-server", "wazuh-server/0", f"grep {pattern} /tmp/data/rsyslog.log"
+            "--container=wazuh-server", "wazuh-server/0", f"grep {pattern} /var/log/collectors/rsyslog.log"
         )
         return True
     except sh.ErrorReturnCode_1:  # pylint: disable=no-member

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,7 +114,7 @@ async def found_in_logs(pattern: str) -> bool:
     """
     try:
         sh.juju.ssh(  # pylint: disable=no-member
-            "--container=wazuh-server", "wazuh-server/0", f"grep {pattern} /tmp/rsyslog.log"
+            "--container=wazuh-server", "wazuh-server/0", f"grep {pattern} /tmp/data/rsyslog.log"
         )
         return True
     except sh.ErrorReturnCode_1:  # pylint: disable=no-member

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,7 +114,9 @@ async def found_in_logs(pattern: str) -> bool:
     """
     try:
         sh.juju.ssh(  # pylint: disable=no-member
-            "--container=wazuh-server", "wazuh-server/0", f"grep {pattern} /var/log/collectors/rsyslog.log"
+            "--container=wazuh-server",
+            "wazuh-server/0",
+            f"grep {pattern} /var/log/collectors/rsyslog.log",
         )
         return True
     except sh.ErrorReturnCode_1:  # pylint: disable=no-member


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Mount value to persist data across container restarts

### Rationale

<!-- The reason the change is needed -->
Restarts cause files with data dumped to disk but not yet processed by the Wazuh manager to get lost, with the subsequent data loss.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
