### PR TITLE
Add storage for collector logs

### DIFF
--- a/rock/rockcraft.yaml
+++ b/rock/rockcraft.yaml
@@ -104,6 +104,7 @@ parts:
     override-stage: |
       # Disable reading logs from the kernel module
       sed -i '/imklog/s/^/#/' $CRAFT_PART_INSTALL/etc/rsyslog.conf
+      sed -i 's/$PrivDropToGroup syslog/$PrivDropToGroup wazuh/g' $CRAFT_PART_INSTALL/etc/rsyslog.conf
       craftctl default
   rsyslog-config:
     plugin: dump

--- a/rock/wazuh.conf
+++ b/rock/wazuh.conf
@@ -22,4 +22,4 @@ $InputTCPServerRun 6514
 # Storing Messages from a Remote System into a specific File 
 #if $fromhost-ip startswith '<ENDPOINT_IP>' then /var/log/endpoint_logs 
 #& ~
-*.* /var/log/collectors/rsyslog.log
+*.* /var/log/collectors/rsyslog/rsyslog.log

--- a/src/charm.py
+++ b/src/charm.py
@@ -178,6 +178,7 @@ class WazuhServerCharm(CharmBaseWithState):
         wazuh.configure_filebeat_user(
             container, self.state.filebeat_username, self.state.filebeat_password
         )
+        wazuh.set_filesystem_permissions(container)
         if self.state.agent_password:
             wazuh.configure_agent_password(container=container, password=self.state.agent_password)
         if self.state.custom_config_repository:

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -357,7 +357,7 @@ def set_filesystem_permissions(container: ops.Container) -> None:
     """
     try:
         process = container.exec(
-            ["chmod", "+t", str(COLLLECTORS_LOG_PATH)],
+            ["chmod", "+wt", str(COLLLECTORS_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -357,7 +357,12 @@ def set_filesystem_permissions(container: ops.Container) -> None:
     """
     try:
         process = container.exec(
-            ["chmod", "+wt", str(COLLLECTORS_LOG_PATH)],
+            ["chmod", "o-rx", str(COLLLECTORS_LOG_PATH)],
+            timeout=1,
+        )
+        process.wait_output()
+        process = container.exec(
+            ["chmown", "syslog:wazuh", str(COLLLECTORS_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -358,6 +358,11 @@ def set_filesystem_permissions(container: ops.Container) -> None:
     """
     try:
         process = container.exec(
+            ["mkdir", "-p", str(COLLECTORS_RSYSLOG_LOG_PATH)],
+            timeout=1,
+        )
+        process.wait_output()
+        process = container.exec(
             ["chmod", "o-rx", str(COLLECTORS_RSYSLOG_LOG_PATH)],
             timeout=1,
         )

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -358,7 +358,7 @@ def set_filesystem_permissions(container: ops.Container) -> None:
     """
     try:
         process = container.exec(
-            ["  ", "o-rx", str(COLLECTORS_RSYSLOG_LOG_PATH)],
+            ["chmod", "o-rx", str(COLLECTORS_RSYSLOG_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -24,8 +24,8 @@ import yaml
 from lxml import etree  # nosec
 
 AGENT_PASSWORD_PATH = Path("/var/ossec/etc/authd.pass")
-COLLLECTORS_LOG_PATH = Path("/var/log/collectors")
-COLLLECTORS_RSYSLOG_LOG_PATH = COLLLECTORS_LOG_PATH / "rsyslog"
+COLLECTORS_LOG_PATH = Path("/var/log/collectors")
+COLLECTORS_RSYSLOG_LOG_PATH = COLLECTORS_LOG_PATH / "rsyslog"
 CONTAINER_NAME = "wazuh-server"
 FILEBEAT_CERTIFICATES_PATH = Path("/etc/filebeat/certs")
 FILEBEAT_USER = "root"
@@ -358,12 +358,12 @@ def set_filesystem_permissions(container: ops.Container) -> None:
     """
     try:
         process = container.exec(
-            ["chmod", "o-rx", str(COLLLECTORS_RSYSLOG_LOG_PATH)],
+            ["  ", "o-rx", str(COLLECTORS_RSYSLOG_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()
         process = container.exec(
-            ["chown", "syslog:wazuh", str(COLLLECTORS_RSYSLOG_LOG_PATH / "rsyslog")],
+            ["chown", "syslog:wazuh", str(COLLECTORS_RSYSLOG_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -24,6 +24,7 @@ import yaml
 from lxml import etree  # nosec
 
 AGENT_PASSWORD_PATH = Path("/var/ossec/etc/authd.pass")
+COLLLECTORS_LOG_PATH = Path("/var/log/collectors")
 CONTAINER_NAME = "wazuh-server"
 FILEBEAT_CERTIFICATES_PATH = Path("/etc/filebeat/certs")
 FILEBEAT_USER = "root"
@@ -338,6 +339,25 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "/root/repository/var/ossec/",
                 "/var/ossec",
             ],
+            timeout=1,
+        )
+        process.wait_output()
+    except ops.pebble.ExecError as ex:
+        raise WazuhInstallationError from ex
+
+
+def set_filesystem_permissions(container: ops.Container) -> None:
+    """Configure the filesystem permissions.
+
+    Args:
+        container: the container to configure the user for.
+
+    Raises:
+        WazuhInstallationError: if an error occurs while setting the permissions.
+    """
+    try:
+        process = container.exec(
+            ["chmod", "+t", str(COLLLECTORS_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -25,6 +25,7 @@ from lxml import etree  # nosec
 
 AGENT_PASSWORD_PATH = Path("/var/ossec/etc/authd.pass")
 COLLLECTORS_LOG_PATH = Path("/var/log/collectors")
+COLLLECTORS_RSYSLOG_LOG_PATH = COLLLECTORS_LOG_PATH / "rsyslog"
 CONTAINER_NAME = "wazuh-server"
 FILEBEAT_CERTIFICATES_PATH = Path("/etc/filebeat/certs")
 FILEBEAT_USER = "root"
@@ -357,12 +358,12 @@ def set_filesystem_permissions(container: ops.Container) -> None:
     """
     try:
         process = container.exec(
-            ["chmod", "o-rx", str(COLLLECTORS_LOG_PATH)],
+            ["chmod", "o-rx", str(COLLLECTORS_RSYSLOG_LOG_PATH)],
             timeout=1,
         )
         process.wait_output()
         process = container.exec(
-            ["chmown", "syslog:wazuh", str(COLLLECTORS_LOG_PATH)],
+            ["chown", "syslog:wazuh", str(COLLLECTORS_RSYSLOG_LOG_PATH / "rsyslog")],
             timeout=1,
         )
         process.wait_output()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -116,7 +116,7 @@ async def found_in_logs(pattern: str) -> bool:
         sh.juju.ssh(  # pylint: disable=no-member
             "--container=wazuh-server",
             "wazuh-server/0",
-            f"grep {pattern} /var/log/collectors/rsyslog.log",
+            f"grep {pattern} /var/log/collectors/rsyslog/rsyslog.log",
         )
         return True
     except sh.ErrorReturnCode_1:  # pylint: disable=no-member

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -86,11 +86,13 @@ def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
+@patch.object(wazuh, "set_filesystem_permissions")
 @patch.object(wazuh, "get_version")
 @patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_active_status_when_repository_and_password_configured(
     filebeat_csr_mock,
     get_version_mock,
+    set_filesystem_permissions_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -174,6 +176,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
         cluster_key,
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
+    set_filesystem_permissions_mock.assert_called_with(container)
     wazuh_configure_agent_password_mock.assert_called_with(
         container=container, password=agent_password
     )
@@ -196,11 +199,13 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
 @patch.object(wazuh, "configure_filebeat_user")
+@patch.object(wazuh, "set_filesystem_permissions")
 @patch.object(wazuh, "get_version")
 @patch.object(CertificatesObserver, "get_csr")
 def test_reconcile_reaches_active_status_when_repository_and_password_not_configured(
     filebeat_csr_mock,
     get_version_mock,
+    set_filesystem_permissions_mock,
     configure_filebeat_user_mock,
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
@@ -273,6 +278,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
         ]
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
+    set_filesystem_permissions_mock.assert_called_with(container)
     wazuh_configure_agent_password_mock.assert_not_called()
     configure_git_mock.assert_not_called()
     pull_configuration_files_mock.assert_not_called()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add a sticky bit to the directory so that only the file owners can delete or rename the log files

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
