### PR TITLE
DO NOT MERGE: remove delete from rsync

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -328,36 +328,39 @@ def configure_git(
 
     base_url = None
     branch = None
-    if custom_config_repository:
-        url = urlsplit(custom_config_repository)
-        path_parts = url.path.split("@")
-        branch = path_parts[1] if len(path_parts) > 1 else None
-        base_url = urlunsplit(url._replace(path=path_parts[0]))
-        process = container.exec(["ssh-keyscan", "-t", "rsa", str(url.hostname)], timeout=10)
-        output, _ = process.wait_output()
-        container.push(
-            KNOWN_HOSTS_PATH,
-            output,
-            encoding="utf-8",
-            make_dirs=True,
-            user=WAZUH_USER,
-            group=WAZUH_GROUP,
-            permissions=0o600,
-        )
-    if (
-        _get_current_configuration_url(container) != base_url
-        or _get_current_configuration_url_branch(container) != branch
-    ):
-        process = container.exec(["rm", "-Rf", REPOSITORY_PATH], timeout=1)
-        process.wait_output()
-
-        if base_url:
-            command = ["git", "clone", "--depth", "1"]
-            if branch:
-                command = command + ["--branch", branch]
-            command = command + [base_url, REPOSITORY_PATH]
-            process = container.exec(command, timeout=60)
+    try:
+        if custom_config_repository:
+            url = urlsplit(custom_config_repository)
+            path_parts = url.path.split("@")
+            branch = path_parts[1] if len(path_parts) > 1 else None
+            base_url = urlunsplit(url._replace(path=path_parts[0]))
+            process = container.exec(["ssh-keyscan", "-t", "rsa", str(url.hostname)], timeout=10)
+            output, _ = process.wait_output()
+            container.push(
+                KNOWN_HOSTS_PATH,
+                output,
+                encoding="utf-8",
+                make_dirs=True,
+                user=WAZUH_USER,
+                group=WAZUH_GROUP,
+                permissions=0o600,
+            )
+        if (
+            _get_current_configuration_url(container) != base_url
+            or _get_current_configuration_url_branch(container) != branch
+        ):
+            process = container.exec(["rm", "-Rf", REPOSITORY_PATH], timeout=1)
             process.wait_output()
+
+            if base_url:
+                command = ["git", "clone", "--depth", "1"]
+                if branch:
+                    command = command + ["--branch", branch]
+                command = command + [base_url, REPOSITORY_PATH]
+                process = container.exec(command, timeout=60)
+                process.wait_output()
+    except ops.pebble.ExecError as ex:
+        raise WazuhInstallationError from ex
 
 
 def pull_configuration_files(container: ops.Container) -> None:
@@ -376,18 +379,22 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "-a",
                 "--chown",
                 "wazuh:wazuh",
-                "--include='*/'",
-                "--include='etc/*.conf'",
-                "--include='etc/decoders/***'",
-                "--include='etc/rules/***'",
-                "--include='etc/shared/*.conf'",
-                "--include='etc/shared/**/*.conf'",
-                "--include='integrations/***'",
-                "--exclude='*'",
+                "--delete",
+                "--include=etc/",
+                "--include=etc/*.conf",
+                "--include=etc/decoders/***",
+                "--include=etc/rules/***",
+                "--include=etc/shared/",
+                "--include=etc/shared/*.conf",
+                "--include=etc/shared/**/",
+                "--include=etc/shared/**/*.conf",
+                "--include=integrations/***",
+                "--include=ruleset/***",
+                "--exclude=*",
                 "/root/repository/var/ossec/",
                 "/var/ossec",
             ],
-            timeout=1,
+            timeout=10,
         )
         process.wait_output()
     except ops.pebble.ExecError as ex:

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -376,7 +376,6 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "-a",
                 "--chown",
                 "wazuh:wazuh",
-                "--delete",
                 "--include='*/'",
                 "--include='etc/*.conf'",
                 "--include='etc/decoders/***'",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Current behaviour-
- rsync command has a delete option which is currently removing all the files in `/var/ossec`. 

Desired behaviour -
- We would like to ideally only remove the only the files in the destination folder which were previously added from src but aren't in src anymore. 


- Temporarily removing the delete option until i finish debugging issues in the configuration files. Will find the right rsync command after that.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
