### PR TITLE
Improve integration testing performance

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,17 +25,6 @@ MACHINE_MODEL_CONFIG = {
     "update-status-hook-interval": "5m",
 }
 
-SYSCONFIG_CONFIG = {
-    "sysctl": """
-    {
-        "vm.max_map_count": 262144,
-        "vm.swappiness": 0,
-        "net.ipv4.tcp_retries2": 5,
-        "fs.file-max": 1048576,
-    }
-"""
-}
-
 
 @pytest_asyncio.fixture(scope="module", name="model")
 async def model_fixture(ops_test: OpsTest) -> Model:
@@ -146,10 +135,6 @@ async def opensearch_provider_fixture(
 
     await machine_model.integrate(self_signed_certificates.name, application.name)
     await machine_model.create_offer(f"{application.name}:opensearch-client", application.name)
-    sysconfig = await machine_model.deploy(
-        "sysconfig", channel="latest/stable", config=SYSCONFIG_CONFIG
-    )
-    await machine_model.integrate(sysconfig.name, application.name)
     yield application
 
 

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -27,3 +27,14 @@ sg snap_microk8s -c "juju switch $TESTING_MODEL"
 IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
 sudo microk8s enable "metallb:$IPADDR-$IPADDR"
 sudo microk8s status
+
+# https://charmhub.io/opensearch/docs/t-set-up#set-parameters-on-the-host-machine
+sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
+vm.max_map_count=262144
+vm.swappiness=0
+net.ipv4.tcp_retries2=5
+fs.file-max=1048576
+EOT
+
+sudo sysctl -p
+


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Rely on the sysconfig charm for integration testing instead of using the model settings

### Rationale

<!-- The reason the change is needed -->
Will result in lower resource consumption for integration testing

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
