### PR TITLE
Change exception to blocked status for missing OpenCTI integration

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-06-23
+
+### Updated
+
+- Changed exception to blocked status for missing OpenCTI integration.
+
 ## 2025-06-19
 
 ### Updated

--- a/src/charm.py
+++ b/src/charm.py
@@ -280,7 +280,10 @@ class WazuhServerCharm(CharmBaseWithState):
         if not self.state:
             self.unit.status = ops.WaitingStatus("Waiting for status to be available.")
             return
-        self._configure_installation(container)
+        try:
+            self._configure_installation(container)
+        except wazuh.OpenCTIIntegrationMissingError:
+            self.unit.status = ops.BlockedStatus("OpenCTI integration is missing.")
         container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
         container.replan()
         self._configure_users()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 
 class OpenCTIIntegrationMissingError(Exception):
-    """OpenCTI integration is missing."""
+    """OpenCTI integration is missing but required."""
 
 
 class WazuhInstallationError(Exception):
@@ -123,6 +123,7 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
         opencti_url: OpenCTI URL.
 
     Raises:
+        OpenCTIIntegrationMissingError: if the OpenCTI integration is missing but required.
         WazuhConfigurationError: if the configuration is invalid or missing required elements.
     """
     ossec_config = container.pull(OSSEC_CONF_PATH, encoding="utf-8").read()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -57,6 +57,10 @@ WAZUH_USER = "wazuh"
 logger = logging.getLogger(__name__)
 
 
+class OpenCTIIntegrationMissingError(Exception):
+    """OpenCTI integration is missing."""
+
+
 class WazuhInstallationError(Exception):
     """Base exception for Wazuh errors."""
 
@@ -147,10 +151,8 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
 
     integrations = ossec_config_tree.xpath(".//integration[starts-with(name, 'custom-opencti-')]")
     if integrations and (not opencti_token or not opencti_url):
-        raise WazuhConfigurationError(
-            "Missing OpenCTI token or url for custom-opencti integrations. "
-            "Ensure OpenCTI is integrated with Wazuh."
-        )
+        logger.error("Missing OpenCTI token or url for custom-opencti integrations.")
+        raise OpenCTIIntegrationMissingError()
 
     for integration in integrations:
         api_key = integration.find("api_key")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Currently Wazuh raises an error if opencti custom integration scripts are present but integration with OpenCTI is missing. This is not the desired behaviour.
Modifying the code to block the charm instead of raising an error.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
