### PR TITLE
Move the charm status setting logic to the reconcile loop

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-06-23
+
+### Updated
+
+- Changed exception to blocked status for missing OpenCTI integration.
+
 ## 2025-06-19
 
 ### Updated

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-06-24
+
+### Updated
+
+- Moved the charm status setting logic to the reconcile loop.
+
 ## 2025-06-23
 
 ### Updated

--- a/src/charm.py
+++ b/src/charm.py
@@ -280,7 +280,10 @@ class WazuhServerCharm(CharmBaseWithState):
         if not self.state:
             self.unit.status = ops.WaitingStatus("Waiting for status to be available.")
             return
-        self._configure_installation(container)
+        try:
+            self._configure_installation(container)
+        except wazuh.OpenCTIIntegrationMissingError:
+            self.unit.status = ops.BlockedStatus("OpenCTI integration is missing.")
         container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
         container.replan()
         self._configure_users()

--- a/src/charm.py
+++ b/src/charm.py
@@ -84,9 +84,7 @@ class WazuhServerCharm(CharmBaseWithState):
         Raises:
             InvalidStateError: if the secret doesn't exist.
         """
-        if not self.state:
-            self.unit.status = ops.WaitingStatus("Waiting for status to be available.")
-            return
+        _ = self.state  # Ensure the state is valid
         if self.unit.is_leader():
             try:
                 secret = self.model.get_secret(label=wazuh_api.WAZUH_API_KEY_SECRET_LABEL)
@@ -106,7 +104,7 @@ class WazuhServerCharm(CharmBaseWithState):
                 raise InvalidStateError from exc
 
     @property
-    def state(self) -> State | None:
+    def state(self) -> State:
         """The charm state."""
         try:
             opensearch_relation = self.model.get_relation(opensearch_observer.RELATION_NAME)
@@ -130,12 +128,10 @@ class WazuhServerCharm(CharmBaseWithState):
             raise exc
         except IncompleteStateError as exc:
             logger.debug("Charm configuration not ready, %s", exc)
-            self.unit.status = ops.WaitingStatus("Charm state is not yet ready")
-            return None
+            raise exc
         except RecoverableStateError as exc:
             logger.error("Invalid charm configuration, %s", exc)
-            self.unit.status = ops.BlockedStatus("Charm state is invalid")
-            return None
+            raise exc
 
     @property
     def external_hostname(self) -> str | None:
@@ -158,10 +154,9 @@ class WazuhServerCharm(CharmBaseWithState):
             return
 
         if not self.state.logs_ca_cert:
-            self.unit.status = ops.BlockedStatus(
-                "Invalid charm configuration 'logs-ca-cert' is missing."
+            raise wazuh.WazuhConfigurationError(
+                "Invalid charm configuration: 'logs-ca-cert' is missing."
             )
-            return
 
         wazuh.install_certificates(
             container=container,
@@ -269,6 +264,7 @@ class WazuhServerCharm(CharmBaseWithState):
 
         This is the main entry for changes that require a restart.
         """
+        self.unit.status = ops.MaintenanceStatus()
         container = self.unit.get_container(wazuh.CONTAINER_NAME)
         if not container.can_connect():
             logger.warning(
@@ -277,24 +273,28 @@ class WazuhServerCharm(CharmBaseWithState):
             )
             self.unit.status = ops.WaitingStatus("Waiting for pebble.")
             return
-        if not self.state:
-            self.unit.status = ops.WaitingStatus("Waiting for status to be available.")
-            return
         try:
+            _ = self.state  # Ensure the state is valid
             self._configure_installation(container)
+            container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
+            container.replan()
+            self._configure_users()
+            self._populate_wazuh_api_relation_data()
+            # Fetch the new wazuh layer, which has different env vars
+            logger.debug("Reconfiguring pebble layers")
+            container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
+            container.add_layer("prometheus", self._prometheus_pebble_layer, combine=True)
+            container.replan()
+            self.unit.set_workload_version(wazuh.get_version(container))
+            self.unit.status = ops.ActiveStatus()
+        except wazuh.WazuhConfigurationError as exc:
+            self.unit.status = ops.BlockedStatus(str(exc))
         except wazuh.OpenCTIIntegrationMissingError:
             self.unit.status = ops.BlockedStatus("OpenCTI integration is missing.")
-        container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
-        container.replan()
-        self._configure_users()
-        self._populate_wazuh_api_relation_data()
-        # Fetch the new wazuh layer, which has different env vars
-        logger.debug("Reconfiguring pebble layers")
-        container.add_layer("wazuh", self._wazuh_pebble_layer, combine=True)
-        container.add_layer("prometheus", self._prometheus_pebble_layer, combine=True)
-        container.replan()
-        self.unit.set_workload_version(wazuh.get_version(container))
-        self.unit.status = ops.ActiveStatus()
+        except RecoverableStateError:
+            self.unit.status = ops.BlockedStatus("Charm state is invalid")
+        except IncompleteStateError:
+            self.unit.status = ops.WaitingStatus("Charm state is not yet ready")
 
     @property
     def _wazuh_pebble_layer(self) -> pebble.LayerDict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -106,26 +106,22 @@ class WazuhServerCharm(CharmBaseWithState):
     @property
     def state(self) -> State:
         """The charm state."""
-        try:
-            opensearch_relation = self.model.get_relation(opensearch_observer.RELATION_NAME)
-            opensearch_relation_data = (
-                opensearch_relation.data[opensearch_relation.app] if opensearch_relation else {}
-            )
-            opencti_relation = self.model.get_relation(opencti_connector_observer.RELATION_NAME)
-            opencti_relation_data = (
-                opencti_relation.data[opencti_relation.app] if opencti_relation else {}
-            )
-            certificates = self.certificates.certificates.get_provider_certificates()
-            return State.from_charm(
-                self,
-                opensearch_relation_data,
-                opencti_relation_data,
-                certificates,
-                self.certificates.get_csr().decode("utf-8"),
-            )
-        except InvalidStateError as exc:
-            logger.error("Invalid charm configuration, %s", exc)
-            raise exc
+        opensearch_relation = self.model.get_relation(opensearch_observer.RELATION_NAME)
+        opensearch_relation_data = (
+            opensearch_relation.data[opensearch_relation.app] if opensearch_relation else {}
+        )
+        opencti_relation = self.model.get_relation(opencti_connector_observer.RELATION_NAME)
+        opencti_relation_data = (
+            opencti_relation.data[opencti_relation.app] if opencti_relation else {}
+        )
+        certificates = self.certificates.certificates.get_provider_certificates()
+        return State.from_charm(
+            self,
+            opensearch_relation_data,
+            opencti_relation_data,
+            certificates,
+            self.certificates.get_csr().decode("utf-8"),
+        )
 
     @property
     def external_hostname(self) -> str | None:
@@ -290,6 +286,9 @@ class WazuhServerCharm(CharmBaseWithState):
         except IncompleteStateError as exc:
             logger.debug("Charm configuration not ready, %s", exc)
             self.unit.status = ops.WaitingStatus("Charm state is not yet ready")
+        except InvalidStateError as exc:
+            logger.error("Invalid charm configuration, %s", exc)
+            self.unit.status = ops.BlockedStatus("Invalid charm configuration")
 
     @property
     def _wazuh_pebble_layer(self) -> pebble.LayerDict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,6 +253,9 @@ class WazuhServerCharm(CharmBaseWithState):
         """Reconcile Wazuh configuration with charm state.
 
         This is the main entry for changes that require a restart.
+
+        Raises:
+            InvalidStateError: if the charm configuration is invalid.
         """
         container = self.unit.get_container(wazuh.CONTAINER_NAME)
         if not container.can_connect():
@@ -288,7 +291,7 @@ class WazuhServerCharm(CharmBaseWithState):
             self.unit.status = ops.WaitingStatus("Charm state is not yet ready")
         except InvalidStateError as exc:
             logger.error("Invalid charm configuration, %s", exc)
-            self.unit.status = ops.BlockedStatus("Invalid charm configuration")
+            raise InvalidStateError from exc
 
     @property
     def _wazuh_pebble_layer(self) -> pebble.LayerDict:

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 
 
 class OpenCTIIntegrationMissingError(Exception):
-    """OpenCTI integration is missing."""
+    """OpenCTI integration is missing but required."""
 
 
 class WazuhInstallationError(Exception):
@@ -123,6 +123,7 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
         opencti_url: OpenCTI URL.
 
     Raises:
+        OpenCTIIntegrationMissingError: if the OpenCTI integration is missing but required.
         WazuhConfigurationError: if the configuration is invalid or missing required elements.
     """
     ossec_config = container.pull(OSSEC_CONF_PATH, encoding="utf-8").read()

--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -57,6 +57,10 @@ WAZUH_USER = "wazuh"
 logger = logging.getLogger(__name__)
 
 
+class OpenCTIIntegrationMissingError(Exception):
+    """OpenCTI integration is missing."""
+
+
 class WazuhInstallationError(Exception):
     """Base exception for Wazuh errors."""
 
@@ -147,10 +151,8 @@ def _update_wazuh_configuration(  # pylint: disable=too-many-locals, too-many-ar
 
     integrations = ossec_config_tree.xpath(".//integration[starts-with(name, 'custom-opencti-')]")
     if integrations and (not opencti_token or not opencti_url):
-        raise WazuhConfigurationError(
-            "Missing OpenCTI token or url for custom-opencti integrations. "
-            "Ensure OpenCTI is integrated with Wazuh."
-        )
+        logger.error("Missing OpenCTI token or url for custom-opencti integrations.")
+        raise OpenCTIIntegrationMissingError()
 
     for integration in integrations:
         api_key = integration.find("api_key")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -54,7 +54,7 @@ def test_invalid_state_reaches_blocked_status(state_from_charm_mock, *_):
     harness = Harness(WazuhServerCharm)
     harness.begin()
 
-    assert harness.charm.state is None
+    # assert harness.charm.state is None
     assert harness.model.unit.status.name == ops.BlockedStatus().name
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -46,15 +46,17 @@ def test_invalid_state_reaches_error_status(state_from_charm_mock, *_):
 def test_invalid_state_reaches_blocked_status(state_from_charm_mock, *_):
     """
     arrange: mock State.from_charm so that it raises a RecoverableStateError.
-    act: instantiate a charm.
-    assert: the charm reaches blocked status when the state is fetched.
+    act: instantiate a charm and call reconcile.
+    assert: the charm reaches blocked status.
     """
     state_from_charm_mock.side_effect = RecoverableStateError()
 
     harness = Harness(WazuhServerCharm)
     harness.begin()
-
-    # assert harness.charm.state is None
+    container = harness.model.unit.containers.get("wazuh-server")
+    assert container
+    harness.set_can_connect(container, True)
+    harness.charm.reconcile(None)
     assert harness.model.unit.status.name == ops.BlockedStatus().name
 
 
@@ -63,15 +65,18 @@ def test_invalid_state_reaches_blocked_status(state_from_charm_mock, *_):
 def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
     """
     arrange: mock State.from_charm so that it raises an IncompleteStateError.
-    act: instantiate a charm.
-    assert: the charm reaches blocked status when the state is fetched.
+    act: instantiate a charm and call reconcile.
+    assert: the charm reaches waiting status.
     """
     state_from_charm_mock.side_effect = IncompleteStateError()
 
     harness = Harness(WazuhServerCharm)
     harness.begin()
+    container = harness.model.unit.containers.get("wazuh-server")
+    assert container
+    harness.set_can_connect(container, True)
+    harness.charm.reconcile(None)
 
-    assert harness.charm.state is None
     assert harness.model.unit.status.name == ops.WaitingStatus().name
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Moved all the charm status setting logic to the reconcile loop.
<!-- A high level overview of the change -->


### Rationale

<!-- The reason the change is needed -->
Currently, the logic of setting charm statuses are handled inside the `state.from_charm` function. This function also returns None in case of Blocked of Waiting Statuses. However, in the reconcile loop, if the state returns None, it sets the charm to WaitingStatus with the message "Waiting for status to be available" making it unclear why the charm is waiting.

Another function that sets the charm status to blocked is `_configure_installation`. However, this function is called inside the reconcile loop and the remaining code continues to execute and Active Status is set in the end. The desired behaviour is to set the charm status to blocked and exit execution.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
