### PR TITLE
Add how to redeploy documentation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-06-24
+
+### Added
+
+- How to redeploy documentation.
+
 ## 2025-06-23
 
 ### Updated

--- a/docs/how-to/redeploy.md
+++ b/docs/how-to/redeploy.md
@@ -1,0 +1,7 @@
+# How to redeploy Wazuh
+
+This guide provides the necessary steps for migrating an existing Wazuh deployment to a new environment.
+
+## Migrate the Indexer data
+
+Follow the instructions in [the OpenSearch charm migration documentation](https://github.com/canonical/opensearch-operator/blob/main/docs/how-to/h-migrate-cluster.md) to migrate the data stored in the Wazuh Indexer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,3 +33,25 @@ The Wazuh Server Operator is a member of the Ubuntu family. It's an open-source 
 - [Contribute](https://charmhub.io/wazuh-server/docs/how-to-contribute)
 
 Thinking about using the Wazuh Server Operator for your next project? [Get in touch](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)!
+
+# Contents
+
+1. [Tutorial](getting-started.md)
+1. [How to](how-to)
+  1. [Backup and restore](how-to/backup-restore.md)
+  1. [Collect logs](how-to/collect-logs.md)
+  1. [Configure](how-to/configure.md)
+  1. [Contribute](how-to/contribute.md)
+  1. [Deploy to production](how-to/deploy-to-production.md)
+  1. [Integrate with OpenCTI](how-to/integrate-with-opencti.md)
+  1. [Redeploy](how-to/redeploy.md)
+  1. [Upgrade](how-to/upgrade.md)
+1. [Reference](reference)
+  1. [Actions](reference/actions.md)
+  1. [Configurations](reference/configurations.md)
+  1. [External access](reference/external-access.md)
+  1. [Integrations](reference/integrations.md)
+1. [Explanation](explanation)
+  1. [Architecture overview](explanation/architecture-overview.md)
+  1. [Charm architecture](explanation/charm-architecture.md) 
+  1. [Security](explanation/security.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,9 +35,9 @@ Thinking about using the Wazuh Server Operator for your next project? [Get in to
 # Contents
 
 1. [Tutorial](tutorial)
-  1. [TutoGetting started](tutorial/getting-started.md)
+  1. [Deploy the Wazuh Server charm for the first time](tutorial/getting-started.md)
 1. [How to](how-to)
-  1. [Backup and restore](how-to/backup-restore.md)
+  1. [Back up and restore](how-to/backup-restore.md)
   1. [Collect logs](how-to/collect-logs.md)
   1. [Configure](how-to/configure.md)
   1. [Contribute](how-to/contribute.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,8 @@ Thinking about using the Wazuh Server Operator for your next project? [Get in to
 
 # Contents
 
-1. [Tutorial](getting-started.md)
+1. [Tutorial](tutorial)
+  1. [TutoGetting started](tutorial/getting-started.md)
 1. [How to](how-to)
   1. [Backup and restore](how-to/backup-restore.md)
   1. [Collect logs](how-to/collect-logs.md)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add how to redeploy documentation

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
