### PR TITLE
Provide s3 credentials to the integrator

### DIFF
--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -255,13 +255,15 @@ module "wazuh_indexer_backup" {
   source = "./modules/s3-integrator"
   model  = data.juju_model.wazuh_indexer.name
 
-  app_name    = "${data.juju_model.wazuh_indexer.name}-backup"
-  channel     = var.wazuh_indexer_backup.channel
-  config      = var.wazuh_indexer_backup.config
-  constraints = var.wazuh_indexer_backup.constraints
-  revision    = var.wazuh_indexer_backup.revision
-  base        = var.wazuh_indexer_backup.base
-  units       = var.wazuh_indexer_backup.units
+  app_name      = "${data.juju_model.wazuh_indexer.name}-backup"
+  channel       = var.wazuh_indexer_backup.channel
+  config        = var.wazuh_indexer_backup.config
+  constraints   = var.wazuh_indexer_backup.constraints
+  revision      = var.wazuh_indexer_backup.revision
+  base          = var.wazuh_indexer_backup.base
+  units         = var.wazuh_indexer_backup.units
+  s3_access_key = var.wazuh_indexer_backup.s3_access_key
+  s3_secret_key = var.wazuh_indexer_backup.s3_secret_key
 
   providers = {
     juju = juju.wazuh_indexer

--- a/terraform/product/modules/s3-integrator/main.tf
+++ b/terraform/product/modules/s3-integrator/main.tf
@@ -15,4 +15,9 @@ resource "juju_application" "s3_integrator" {
   config      = var.config
   constraints = var.constraints
   units       = var.units
+
+  provisioner "local-exec" {
+    # There's currently no way to wait for the charm to be idle, hence the sleep
+    command = "sleep 60; juju run ${self.name}/leader sync-s3-credentials access-key=${var.s3_access_key} secret-key=${var_secret_key}; "
+  }
 }

--- a/terraform/product/modules/s3-integrator/variables.tf
+++ b/terraform/product/modules/s3-integrator/variables.tf
@@ -48,3 +48,11 @@ variable "units" {
   type        = number
   default     = 1
 }
+
+variable "s3_access_key" {
+  type = string
+}
+
+variable "s3_secret_key" {
+  type = string
+}


### PR DESCRIPTION
I applied what is done in https://github.com/canonical/is-prod-synapse-k8s/blob/main/s3_integrators.tf to populate the s3 integrator. If you have another approach to suggest, it's welcome :)