### PR TITLE
Add relation departed hooks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-06-30
+
+### Added
+
+- Adding `<endpoint>-relation-departed` hooks for opensearch_observer, 
+opencti_connector, wazuh_api and wazuh_peer integrations.
+
 ## 2025-06-24
 
 ### Added

--- a/src/charm.py
+++ b/src/charm.py
@@ -65,7 +65,7 @@ class WazuhServerCharm(CharmBaseWithState):
         self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_changed, self.reconcile)
         self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_departed, self.reconcile)
         self.framework.observe(self.on[wazuh_api.RELATION_NAME].relation_changed, self.reconcile)
-        self.framework.observe(self.on[wazuh_api.RELATION_NAME].relation_departed, self.reconcile)
+        self.framework.observe(self.on[wazuh_api.RELATION_NAME].relation_broken, self.reconcile)
 
     def _on_install(self, _: ops.InstallEvent) -> None:
         """Install event handler."""
@@ -289,7 +289,7 @@ class WazuhServerCharm(CharmBaseWithState):
             logger.error("Invalid charm configuration, %s", exc)
             self.unit.status = ops.BlockedStatus("Charm state is invalid")
         except IncompleteStateError as exc:
-            logger.debug("Charm configuration not ready, %s", exc)
+            logger.error("Charm configuration not ready, %s", exc)
             self.unit.status = ops.WaitingStatus("Charm state is not yet ready")
         except InvalidStateError as exc:
             logger.error("Invalid charm configuration, %s", exc)

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,7 +63,9 @@ class WazuhServerCharm(CharmBaseWithState):
         self.framework.observe(self.on.config_changed, self.reconcile)
         self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_joined, self.reconcile)
         self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_changed, self.reconcile)
+        self.framework.observe(self.on[WAZUH_PEER_RELATION_NAME].relation_departed, self.reconcile)
         self.framework.observe(self.on[wazuh_api.RELATION_NAME].relation_changed, self.reconcile)
+        self.framework.observe(self.on[wazuh_api.RELATION_NAME].relation_departed, self.reconcile)
 
     def _on_install(self, _: ops.InstallEvent) -> None:
         """Install event handler."""

--- a/src/opencti_connector_observer.py
+++ b/src/opencti_connector_observer.py
@@ -34,7 +34,7 @@ class OpenCTIObserver(Object):
             self._charm.on.opencti_connector_relation_changed, self._charm.reconcile
         )
         self.framework.observe(
-            self._charm.on.opencti_connector_relation_departed, self._charm.reconcile
+            self._charm.on.opencti_connector_relation_broken, self._charm.reconcile
         )
 
     def _on_opencti_relation_joined(self, event: ops.RelationJoinedEvent) -> None:

--- a/src/opencti_connector_observer.py
+++ b/src/opencti_connector_observer.py
@@ -33,6 +33,9 @@ class OpenCTIObserver(Object):
         self.framework.observe(
             self._charm.on.opencti_connector_relation_changed, self._charm.reconcile
         )
+        self.framework.observe(
+            self._charm.on.opencti_connector_relation_departed, self._charm.reconcile
+        )
 
     def _on_opencti_relation_joined(self, event: ops.RelationJoinedEvent) -> None:
         """Handle OpenCTI relation joined event.

--- a/src/opensearch_observer.py
+++ b/src/opensearch_observer.py
@@ -32,3 +32,6 @@ class OpenSearchObserver(Object):
         self.framework.observe(
             self._charm.on.opensearch_client_relation_changed, self._charm.reconcile
         )
+        self.framework.observe(
+            self._charm.on.opensearch_client_relation_departed, self._charm.reconcile
+        )

--- a/src/opensearch_observer.py
+++ b/src/opensearch_observer.py
@@ -33,5 +33,5 @@ class OpenSearchObserver(Object):
             self._charm.on.opensearch_client_relation_changed, self._charm.reconcile
         )
         self.framework.observe(
-            self._charm.on.opensearch_client_relation_departed, self._charm.reconcile
+            self._charm.on.opensearch_client_relation_broken, self._charm.reconcile
         )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Adding `<endpoint>-relation-departed` hooks for opensearch_observer, opencti_connector, wazuh_api and wazuh_peer integrations. 

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->
Currently, if any of the above integrations are removed, the wazuh-server charm remains in idle/active state. However, this is not the desired state of wazuh-server. It must ideally be blocked due to missing integration data. While there is no use case for such a scenario, this could lead to inconsistent state and difficulty in debugging for developers.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
