### PR TITLE
Remove auto-configuration as it doesn't work cross models

### DIFF
--- a/terraform/product/main.tf
+++ b/terraform/product/main.tf
@@ -262,8 +262,6 @@ module "wazuh_indexer_backup" {
   revision      = var.wazuh_indexer_backup.revision
   base          = var.wazuh_indexer_backup.base
   units         = var.wazuh_indexer_backup.units
-  s3_access_key = var.wazuh_indexer_backup.s3_access_key
-  s3_secret_key = var.wazuh_indexer_backup.s3_secret_key
 
   providers = {
     juju = juju.wazuh_indexer

--- a/terraform/product/modules/s3-integrator/main.tf
+++ b/terraform/product/modules/s3-integrator/main.tf
@@ -15,9 +15,4 @@ resource "juju_application" "s3_integrator" {
   config      = var.config
   constraints = var.constraints
   units       = var.units
-
-  provisioner "local-exec" {
-    # There's currently no way to wait for the charm to be idle, hence the sleep
-    command = "sleep 60; juju run ${self.name}/leader sync-s3-credentials access-key=${var.s3_access_key} secret-key=${var.s3_secret_key}; "
-  }
 }

--- a/terraform/product/modules/s3-integrator/variables.tf
+++ b/terraform/product/modules/s3-integrator/variables.tf
@@ -48,11 +48,3 @@ variable "units" {
   type        = number
   default     = 1
 }
-
-variable "s3_access_key" {
-  type = string
-}
-
-variable "s3_secret_key" {
-  type = string
-}


### PR DESCRIPTION
There's not clean way to tell terraform to run the action in a different model. So for now we disable auto-config and will document the manual post-deployment step.