### PR TITLE
Update link to setup Canonical Kubernetes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 To make contributions to this charm, you'll need a working development setup with the following requirements met:
 * Juju 3 installed and bootstrapped to an LXD controller. You can accomplish
 this process by using a [Multipass](https://multipass.run/) VM as outlined in this guide: [How to manage your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/). Note that this tutorial provides documentation for both manual and automatic deployment management. You would have to follow the manual steps only to avoid installing MicroK8s in your setup.
-* Canonical Kubernetes installed and bootstrapped to Juju. This can be accomplished by following the [Setup Canonical Kubernetes](to-be-updated) section in the getting started tutorial for Wazuh server.
+* Canonical Kubernetes installed and bootstrapped to Juju. This can be accomplished by following the [Setup Canonical Kubernetes](https://charmhub.io/wazuh-server/docs/tutorial-getting-started#p-38194-set-up-canonical-kubernetes) section in the getting started tutorial for Wazuh server.
 
 ## Set up Docker
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Wazuh documentation has been successfully published on charmhub. Updating the link on how to setup Canonical Kubernetes.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
