### PR TITLE
Ensure integration scripts are executable

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -382,7 +382,6 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "--include=etc/shared/*.conf",
                 "--include=etc/shared/**/",
                 "--include=etc/shared/**/*.conf",
-                "--include=integrations/***",
                 "--exclude=*",
                 "/root/repository/var/ossec/",
                 "/var/ossec",
@@ -399,6 +398,24 @@ def pull_configuration_files(container: ops.Container) -> None:
                 "--chown",
                 "root:wazuh",
                 "--include=ruleset/***",
+                "--exclude=*",
+                "/root/repository/var/ossec/",
+                "/var/ossec",
+            ],
+            timeout=10,
+        )
+        process.wait_output()
+
+        # Copy integration files with executable permissions
+        process = container.exec(
+            [
+                "rsync",
+                "-a",
+                "--chown",
+                "root:wazuh",
+                "--chmod",
+                "755",
+                "--include=integrations/***",
                 "--exclude=*",
                 "/root/repository/var/ossec/",
                 "/var/ossec",


### PR DESCRIPTION
Applicable spec: NA

### Overview

Separates the `rsync` of integration files and ensures they are `chmod`'d to 755. (Wazuh requires integration scripts to be executable)

### Rationale

Eliminate the footgun of not setting the integration files in your config repository to be executable

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated **NA**
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) **NA**
