### PR TITLE
Added necessary permissions to the integration scripts and /shared/de…

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -406,6 +406,36 @@ def pull_configuration_files(container: ops.Container) -> None:
             timeout=10,
         )
         process.wait_output()
+
+        # Find all files within the integrations directory and make them executable.
+        # This ensures all integration scripts are runnable by the wazuh group.
+        process = container.exec(
+            [
+                "find",
+                "/var/ossec/integrations",
+                "-type",
+                "f",
+                "-exec",
+                "chmod",
+                "750",
+                "{}",
+                "+",
+            ],
+            timeout=10,
+        )
+        process.wait_output()
+
+        # Adds correct permissions to the /etc/shared/default directory
+        # 770 required for the manager to create the merged.mg file
+        process = container.exec(
+            [
+                "chmod",
+                "770",
+                "/var/ossec/etc/shared/default",
+            ],
+            timeout=10,
+        )
+        process.wait_output()
     except ops.pebble.ExecError as ex:
         raise WazuhInstallationError from ex
 


### PR DESCRIPTION


Applicable spec: NA

### Overview

Adds chmod commands after the rsync to ensure the correct permissions of the integrations scripts and the /var/ossec/etc/shared/default folder

### Rationale

Eliminate the challenge of not setting the integration files in your config repository to be executable

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
