### PR TITLE
Bugfix + new features

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -136,20 +136,6 @@ class WazuhServerCharm(CharmBaseWithState):
         )
         return traefik_route_relation_data.get("external_host")
 
-    def _reconcile_config_repo(self, container: ops.Container) -> None:
-        """Reconcile the custom config repository
-
-        Args:
-            container: the container to configure Wazuh for.
-        """
-        if self.state.custom_config_repository:
-            wazuh.sync_config_repo(
-                container,
-                custom_config_repository=str(self.state.custom_config_repository),
-                custom_config_ssh_key=self.state.custom_config_ssh_key,
-            )
-        return
-    
     def _reconcile_filebeat(self, container: ops.Container) -> None:
         """Reconcile the filebeat configuration
 
@@ -290,7 +276,11 @@ class WazuhServerCharm(CharmBaseWithState):
             return
         try:
             _ = self.state  # Ensure the state is valid
-            self._reconcile_config_repo(container)
+            wazuh.sync_config_repo(
+                container,
+                custom_config_repository=self.state.custom_config_repository,
+                custom_config_ssh_key=self.state.custom_config_ssh_key,
+            )
             self._reconcile_filebeat(container)
             self._reconcile_rsyslog(container)
             self._reconcile_wazuh(container)

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,12 +72,12 @@ class WazuhServerCharm(CharmBaseWithState):
         """Install event handler."""
         if self.unit.is_leader():
             try:
-                self.model.get_secret(label=WAZUH_CLUSTER_KEY_SECRET_LABEL)
+                _ = self.model.get_secret(label=WAZUH_CLUSTER_KEY_SECRET_LABEL)
             except ops.SecretNotFoundError:
-                logger.debug(
+                logger.info(
                     "Secret with label %s not found. Creating one.", WAZUH_CLUSTER_KEY_SECRET_LABEL
                 )
-                self.app.add_secret(
+                _ = self.app.add_secret(
                     {"value": secrets.token_hex(16)}, label=WAZUH_CLUSTER_KEY_SECRET_LABEL
                 )
 
@@ -267,6 +267,7 @@ class WazuhServerCharm(CharmBaseWithState):
         Raises:
             InvalidStateError: if the charm configuration is invalid.
         """
+        logger.debug("Starting reconciliation")
         reconcile_start_time = time.perf_counter()
         container: ops.Container = self.unit.get_container(wazuh.CONTAINER_NAME)
         if not container.can_connect():

--- a/src/state.py
+++ b/src/state.py
@@ -101,8 +101,8 @@ def _fetch_filebeat_configuration(
         raise IncompleteStateError("Indexer secret ID not yet in relation.")
     try:
         filebeat_secret_content = model.get_secret(id=filebeat_secret_id).get_content()
-    except ops.SecretNotFoundError as exc:
-        raise InvalidStateError("Indexer secret content not found.") from exc
+    except (ops.SecretNotFoundError, ops.model.ModelError) as exc:
+        raise InvalidStateError("Indexer secret content not found or permission denied.") from exc
     filebeat_username = filebeat_secret_content.get("username", "")
     filebeat_password = filebeat_secret_content.get("password", "")
     endpoint_data = indexer_relation_data.get("endpoints")

--- a/src/state.py
+++ b/src/state.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 
 import charms.tls_certificates_interface.v3.tls_certificates as certificates
 import ops
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, ValidationError, parse_obj_as
+from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError, parse_obj_as
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class WazuhConfig(BaseModel):  # pylint: disable=too-few-public-methods
     """
 
     agent_password: str | None = None
-    custom_config_repository: AnyUrl | None = None
+    custom_config_repository: str | None = None
     custom_config_ssh_key: str | None = None
     logs_ca_cert: str
 
@@ -284,7 +284,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
     filebeat_password: str = Field(..., min_length=1)
     certificate: str = Field(..., min_length=1)
     root_ca: str = Field(..., min_length=1)
-    custom_config_repository: AnyUrl | None = None
+    custom_config_repository: str | None = None
     custom_config_ssh_key: str | None = None
     logs_ca_cert: str | None = None
     opencti_url: str | None = None

--- a/src/state.py
+++ b/src/state.py
@@ -263,7 +263,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
         agent_password: the agent password.
         api_credentials: a map containing the API credentials.
         cluster_key: the Wazuh key for the cluster nodes.
-        indexer_ips: list of Wazuh indexer IPs.
+        indexer_endpoints: list of Wazuh indexer endpoints.
         filebeat_username: the filebeat username.
         filebeat_password: the filebeat password.
         certificate: the TLS certificate for filebeat.
@@ -279,7 +279,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
     agent_password: str | None = None
     api_credentials: dict[str, str]
     cluster_key: str = Field(min_length=32, max_length=32)
-    indexer_ips: typing.Annotated[list[str], Field(min_length=1)]
+    indexer_endpoints: typing.Annotated[list[str], Field(min_length=1)]
     filebeat_username: str = Field(..., min_length=1)
     filebeat_password: str = Field(..., min_length=1)
     certificate: str = Field(..., min_length=1)
@@ -295,7 +295,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
         agent_password: str | None,
         api_credentials: dict[str, str],
         cluster_key: str,
-        indexer_ips: list[str],
+        indexer_endpoints: list[str],
         filebeat_username: str,
         filebeat_password: str,
         certificate: str,
@@ -311,7 +311,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
             agent_password: the agent password.
             api_credentials: a map ccontaining the API credentials.
             cluster_key: the Wazuh key for the cluster nodes.
-            indexer_ips: list of Wazuh indexer IPs.
+            indexer_endpoints: list of Wazuh indexer endpoints.
             filebeat_username: the filebeat username.
             filebeat_password: the filebeat password.
             certificate: the TLS certificate for filebeat.
@@ -325,7 +325,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
             agent_password=agent_password,
             api_credentials=api_credentials,
             cluster_key=cluster_key,
-            indexer_ips=indexer_ips,
+            indexer_endpoints=indexer_endpoints,
             filebeat_username=filebeat_username,
             filebeat_password=filebeat_password,
             certificate=certificate,
@@ -413,7 +413,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods
                     agent_password=agent_password,
                     api_credentials=api_credentials,
                     cluster_key=cluster_key,
-                    indexer_ips=endpoints,
+                    indexer_endpoints=endpoints,
                     filebeat_username=filebeat_username,
                     filebeat_password=filebeat_password,
                     certificate=matching_certificates[0].certificate,

--- a/tests/unit/test_certificates_observer.py
+++ b/tests/unit/test_certificates_observer.py
@@ -60,7 +60,7 @@ class ObservedCharm(state.CharmBaseWithState):
             cluster_key=cluster_key,
             certificate="certificate",
             root_ca="root_ca",
-            indexer_ips=["10.0.0.1"],
+            indexer_endpoints=["10.0.0.1"],
             filebeat_username="user1",
             filebeat_password=password,
             wazuh_config=state.WazuhConfig(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -109,12 +109,12 @@ def test_no_logs_ca_cert_reaches_blocked_status(state_from_charm_mock, *_):
 
 
 # pylint: disable=too-many-arguments, too-many-locals, too-many-positional-arguments
+@patch.object(wazuh, "sync_wazuh_config_files")
 @patch.object(wazuh, "create_readonly_api_user")
 @patch.object(wazuh, "authenticate_user")
 @patch.object(wazuh, "change_api_password")
 @patch.object(State, "from_charm")
 @patch.object(wazuh, "sync_config_repo", spec=wazuh.sync_config_repo)
-@patch.object(wazuh, "pull_configuration_files")
 @patch.object(wazuh, "update_configuration")
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
@@ -130,7 +130,6 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
     wazuh_update_configuration_mock,
-    pull_configuration_files_mock,
     sync_config_repo_mock,
     state_from_charm_mock,
     *_,
@@ -204,7 +203,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
                 group="syslog",
             ),
         ],
-        any_order=True
+        any_order=True,
     )
     wazuh_update_configuration_mock.assert_called_with(
         container,
@@ -233,7 +232,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "change_api_password")
 @patch.object(State, "from_charm")
 @patch.object(wazuh, "pull_config_repo")
-@patch.object(wazuh, "pull_configuration_files")
+@patch.object(wazuh, "sync_wazuh_config_files")
 @patch.object(wazuh, "update_configuration")
 @patch.object(wazuh, "configure_agent_password")
 @patch.object(wazuh, "install_certificates")
@@ -249,7 +248,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
     wazuh_install_certificates_mock,
     wazuh_configure_agent_password_mock,
     wazuh_update_configuration_mock,
-    pull_configuration_files_mock,
+    sync_wazuh_config_files_mock,
     pull_config_repo_mock,
     state_from_charm_mock,
     *_,
@@ -315,13 +314,13 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
                 group="syslog",
             ),
         ],
-        any_order=True
+        any_order=True,
     )
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
     set_filesystem_permissions_mock.assert_called_with(container)
     wazuh_configure_agent_password_mock.assert_not_called()
     pull_config_repo_mock.assert_not_called()
-    pull_configuration_files_mock.assert_not_called()
+    sync_wazuh_config_files_mock.assert_not_called()
     wazuh_update_configuration_mock.assert_called_with(
         container,
         ["10.0.0.1"],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -80,7 +80,7 @@ def test_incomplete_state_reaches_waiting_status(state_from_charm_mock, *_):
     assert harness.model.unit.status.name == ops.WaitingStatus().name
 
 
-@patch.object(WazuhServerCharm, "_reconcile_config_repo")
+@patch.object(wazuh, "sync_config_repo")
 @patch.object(WazuhServerCharm, "_reconcile_filebeat")
 @patch.object(WazuhServerCharm, "_reconcile_wazuh")
 @patch.object(CertificatesObserver, "get_csr")
@@ -232,7 +232,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_configured
 @patch.object(wazuh, "authenticate_user")
 @patch.object(wazuh, "change_api_password")
 @patch.object(State, "from_charm")
-@patch.object(wazuh, "sync_config_repo")
+@patch.object(wazuh, "pull_config_repo")
 @patch.object(wazuh, "pull_configuration_files")
 @patch.object(wazuh, "update_configuration")
 @patch.object(wazuh, "configure_agent_password")
@@ -250,7 +250,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
     wazuh_configure_agent_password_mock,
     wazuh_update_configuration_mock,
     pull_configuration_files_mock,
-    sync_config_repo_mock,
+    pull_config_repo_mock,
     state_from_charm_mock,
     *_,
 ):
@@ -320,7 +320,7 @@ def test_reconcile_reaches_active_status_when_repository_and_password_not_config
     configure_filebeat_user_mock.assert_called_with(container, "user1", password)
     set_filesystem_permissions_mock.assert_called_with(container)
     wazuh_configure_agent_password_mock.assert_not_called()
-    sync_config_repo_mock.assert_not_called()
+    pull_config_repo_mock.assert_not_called()
     pull_configuration_files_mock.assert_not_called()
     wazuh_update_configuration_mock.assert_called_with(
         container,

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -105,7 +105,7 @@ def test_state_without_proxy():
     assert charm_state.api_credentials
     assert charm_state.api_credentials["value"] == value
     assert charm_state.cluster_key == value
-    assert charm_state.indexer_ips == endpoints
+    assert charm_state.indexer_endpoints == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
     assert charm_state.certificate == "certificate"
@@ -167,7 +167,7 @@ def test_state_with_proxy(monkeypatch: pytest.MonkeyPatch):
     assert charm_state.api_credentials
     assert charm_state.api_credentials["value"] == value
     assert charm_state.cluster_key == value
-    assert charm_state.indexer_ips == endpoints
+    assert charm_state.indexer_endpoints == endpoints
     assert charm_state.certificate == "certificate"
     assert charm_state.root_ca == "root_ca"
     assert charm_state.filebeat_username == username
@@ -501,7 +501,7 @@ def test_state_when_repository_secret_valid(monkeypatch: pytest.MonkeyPatch):
     )
 
     assert charm_state.cluster_key == value
-    assert charm_state.indexer_ips == endpoints
+    assert charm_state.indexer_endpoints == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
     assert charm_state.certificate == "certificate"
@@ -567,7 +567,7 @@ def test_state_when_agent_password_secret_valid(monkeypatch: pytest.MonkeyPatch)
     )
 
     assert charm_state.cluster_key == value
-    assert charm_state.indexer_ips == endpoints
+    assert charm_state.indexer_endpoints == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
     assert charm_state.certificate == "certificate"
@@ -631,7 +631,7 @@ def test_state_when_logs_ca_cert_valid(monkeypatch: pytest.MonkeyPatch):
     )
 
     assert charm_state.cluster_key == value
-    assert charm_state.indexer_ips == endpoints
+    assert charm_state.indexer_endpoints == endpoints
     assert charm_state.filebeat_username == username
     assert charm_state.filebeat_password == password
     assert charm_state.certificate == "certificate"

--- a/tests/unit/test_wazuh.py
+++ b/tests/unit/test_wazuh.py
@@ -177,6 +177,11 @@ def test_configure_git_when_branch_specified() -> None:
         result="",
     )
     harness.handle_exec(
+        "wazuh-server",
+        ["git", "-C", wazuh.REPOSITORY_PATH, "describe", "--tags", "--exact-match"],
+        result="",
+    )
+    harness.handle_exec(
         "wazuh-server", ["ssh-keyscan", "-t", "rsa", "git.server"], result="know_host"
     )
     harness.handle_exec("wazuh-server", ["rm", "-Rf", wazuh.REPOSITORY_PATH], result="")
@@ -198,12 +203,12 @@ def test_configure_git_when_branch_specified() -> None:
     harness.begin_with_initial_hooks()
     container = harness.charm.unit.get_container("wazuh-server")
     custom_config_ssh_key = "somekey"
-    wazuh.configure_git(container, custom_config_repository, custom_config_ssh_key)
+    wazuh.sync_config_repo(container, custom_config_repository, custom_config_ssh_key)
     assert "know_host" == container.pull(wazuh.KNOWN_HOSTS_PATH, encoding="utf-8").read()
     assert "somekey\n" == container.pull(wazuh.RSA_PATH, encoding="utf-8").read()
 
 
-def test_configure_git_when_no_branch_specified() -> None:
+def test_sync_config_repo_when_no_branch_specified() -> None:
     """
     arrange: do nothing.
     act: configure git without specifying a branch name.
@@ -218,6 +223,11 @@ def test_configure_git_when_no_branch_specified() -> None:
     harness.handle_exec(
         "wazuh-server",
         ["git", "-C", wazuh.REPOSITORY_PATH, "rev-parse", "--abbrev-ref", "HEAD"],
+        result="",
+    )
+    harness.handle_exec(
+        "wazuh-server",
+        ["git", "-C", wazuh.REPOSITORY_PATH, "describe", "--tags", "--exact-match"],
         result="",
     )
     harness.handle_exec(
@@ -240,12 +250,12 @@ def test_configure_git_when_no_branch_specified() -> None:
     harness.begin_with_initial_hooks()
     container = harness.charm.unit.get_container("wazuh-server")
     custom_config_ssh_key = "somekey"
-    wazuh.configure_git(container, custom_config_repository, custom_config_ssh_key)
+    wazuh.sync_config_repo(container, custom_config_repository, custom_config_ssh_key)
     assert "know_host" == container.pull(wazuh.KNOWN_HOSTS_PATH, encoding="utf-8").read()
     assert "somekey\n" == container.pull(wazuh.RSA_PATH, encoding="utf-8").read()
 
 
-def test_configure_git_when_no_key_no_repository_specified() -> None:
+def test_sync_config_repo_when_no_key_no_repository_specified() -> None:
     """
     arrange: do nothing.
     act: configure git without specifying a repository.
@@ -265,7 +275,7 @@ def test_configure_git_when_no_key_no_repository_specified() -> None:
     harness.handle_exec("wazuh-server", ["rm", "-Rf", wazuh.REPOSITORY_PATH], result="")
     harness.begin_with_initial_hooks()
     container = harness.charm.unit.get_container("wazuh-server")
-    wazuh.configure_git(container, None, None)
+    wazuh.sync_config_repo(container, None, None)
     assert not container.exists(wazuh.KNOWN_HOSTS_PATH)
     assert not container.exists(wazuh.RSA_PATH)
 


### PR DESCRIPTION
Applicable spec: NA

### Overview

A larger-than-ideal PR, but the code changes for all items are closely related.

Fixes #252 and #251 

Fixes the 'is config repo up-to-date' logic
- previous approach checked if the right repo URL and branch were present, and did not pull the repo if they were correct
- however, the pull should NOT be skipped in that case, because that branch may have new commits
- the only scenario where we can be sure no update is needed is if the tag is up-to-date - that is the logic that has been implemented

Restarts services if their config files have changed
- previously, services were never restarted, and new configs (even if present on-disk) were never loaded
- most `_configure*` functions are now `sync*` functions and return a bool indicating whether changes were made

rsyslog is now configurable via the custom_config_repository

### Rationale

See above

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated **NA**
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) **NA**
