### PR TITLE
Fix: never-ending integration test cleanup

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -82,20 +82,22 @@ async def traefik_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy the traefik charm."""
     app_name = "traefik-k8s"
+    application: Application
     if pytestconfig.getoption("--no-deploy") and app_name in model.applications:
         logger.warning("Using existing application: %s", app_name)
-        yield model.applications[app_name]
-        return
-
-    application = await model.deploy(
-        app_name,
-        application_name=app_name,
-        channel="latest/edge",
-        revision=233,
-        trust=True,
-        config={"external_hostname": "wazuh-server.local"},
-    )
+        application = model.applications[app_name]
+    else:
+        application = await model.deploy(
+            app_name,
+            application_name=app_name,
+            channel="latest/edge",
+            revision=233,
+            trust=True,
+            config={"external_hostname": "wazuh-server.local"},
+        )
     yield application
+    if not pytestconfig.getoption("--keep-models") and app_name in model.applications:
+        await model.applications[app_name].destroy(force=True, no_wait=True)
 
 
 @pytest_asyncio.fixture(scope="module", name="self_signed_certificates")
@@ -105,19 +107,21 @@ async def self_signed_certificates_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy the self signed certificates charm."""
     app_name = "self-signed-certificates"
+    application: Application
     if pytestconfig.getoption("--no-deploy") and app_name in machine_model.applications:
         logger.warning("Using existing application: %s", app_name)
-        yield machine_model.applications[app_name]
-        return
-
-    application = await machine_model.deploy(
-        app_name,
-        application_name=app_name,
-        channel="latest/stable",
-        config={"ca-common-name": "Test CA"},
-    )
-    await machine_model.create_offer(f"{application.name}:certificates", application.name)
+        application = machine_model.applications[app_name]
+    else:
+        application = await machine_model.deploy(
+            app_name,
+            application_name=app_name,
+            channel="latest/stable",
+            config={"ca-common-name": "Test CA"},
+        )
+        await machine_model.create_offer(f"{application.name}:certificates", application.name)
     yield application
+    if not pytestconfig.getoption("--keep-models") and app_name in machine_model.applications:
+        await machine_model.applications[app_name].destroy(force=True, no_wait=True)
 
 
 @pytest_asyncio.fixture(scope="module", name="opensearch_provider")
@@ -129,36 +133,35 @@ async def opensearch_provider_fixture(
     """Deploy the opensearch charm."""
     app_name = "wazuh-indexer"
     machine_controller_name = (await machine_model.get_controller()).controller_name
-
+    application: Application
     if pytestconfig.getoption("--no-deploy") and app_name in machine_model.applications:
         logger.warning("Using existing application: %s", app_name)
-        yield machine_model.applications[app_name]
-        return
-
-    num_units = 3
-    if pytestconfig.getoption("--single-node-indexer"):
-        num_units = 1
-    application = await machine_model.deploy(
-        app_name,
-        application_name=app_name,
-        channel=WAZUH_INDEXER_CHANNEL,
-        revision=WAZUH_INDEXER_REVISION,
-        num_units=num_units,
-        config={"profile": "testing"},
-    )
-    await machine_model.integrate(self_signed_certificates.name, application.name)
-    await machine_model.wait_for_idle(
-        apps=[application.name],
-        status="active",
-        raise_on_error=True,
-        timeout=1800,
-    )
-
-    if num_units == 1:
-        await configure_single_node(f"{machine_controller_name}:admin/{machine_model.name}")
-
-    await machine_model.create_offer(f"{application.name}:opensearch-client", application.name)
+        application = machine_model.applications[app_name]
+    else:
+        num_units = 3
+        if pytestconfig.getoption("--single-node-indexer"):
+            num_units = 1
+        application = await machine_model.deploy(
+            app_name,
+            application_name=app_name,
+            channel=WAZUH_INDEXER_CHANNEL,
+            revision=WAZUH_INDEXER_REVISION,
+            num_units=num_units,
+            config={"profile": "testing"},
+        )
+        await machine_model.integrate(self_signed_certificates.name, application.name)
+        await machine_model.wait_for_idle(
+            apps=[application.name],
+            status="active",
+            raise_on_error=True,
+            timeout=1800,
+        )
+        if num_units == 1:
+            await configure_single_node(f"{machine_controller_name}:admin/{machine_model.name}")
+        await machine_model.create_offer(f"{application.name}:opensearch-client", application.name)
     yield application
+    if not pytestconfig.getoption("--keep-models") and app_name in machine_model.applications:
+        await machine_model.applications[app_name].destroy(force=True, no_wait=True)
 
 
 @pytest_asyncio.fixture(scope="module", name="wazuh_dashboard")
@@ -170,25 +173,26 @@ async def wazuh_dashboard_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy the opensearch charm."""
     app_name = "wazuh-dashboard"
+    application: Application
     if pytestconfig.getoption("--no-deploy") and app_name in machine_model.applications:
         logger.warning("Using existing application: %s", app_name)
-        yield machine_model.applications[app_name]
-        return
-
-    num_units = 1
-    application = await machine_model.deploy(
-        app_name,
-        application_name=app_name,
-        channel=WAZUH_DASHBOARD_CHANNEL,
-        revision=WAZUH_DASHBOARD_REVISION,
-        num_units=num_units,
-    )
-    await machine_model.integrate(self_signed_certificates.name, application.name)
-    await machine_model.integrate(opensearch_provider.name, application.name)
+        application = machine_model.applications[app_name]
+    else:
+        num_units = 1
+        application = await machine_model.deploy(
+            app_name,
+            application_name=app_name,
+            channel=WAZUH_DASHBOARD_CHANNEL,
+            revision=WAZUH_DASHBOARD_REVISION,
+            num_units=num_units,
+        )
+        await machine_model.integrate(self_signed_certificates.name, application.name)
+        await machine_model.integrate(opensearch_provider.name, application.name)
     yield application
-    await machine_model.applications[app_name].destroy(
-        destroy_storage=True, force=True, no_wait=False
-    )
+    if not pytestconfig.getoption("--keep-models") and app_name in machine_model.applications:
+        await machine_model.applications[app_name].destroy(
+            destroy_storage=True, force=True, no_wait=False
+        )
 
 
 @pytest_asyncio.fixture(scope="module", name="charm")
@@ -264,24 +268,26 @@ async def opencti_any_charm_fixture(
     application: Application,
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy OpenCTI any-charm and integrate with Wazuh Server."""
-    any_app_name = "any-opencti"
+    app_name = "any-opencti"
     any_charm_script = Path("tests/integration/any_charm.py").read_text(encoding="utf-8")
     any_charm_src_overwrite = {"any_charm.py": any_charm_script}
     any_app: Application
-    if pytestconfig.getoption("--no-deploy") and any_app_name in model.applications:
-        logger.warning("Using existing application: %s", any_app_name)
-        any_app = model.applications[any_app_name]
+    if pytestconfig.getoption("--no-deploy") and app_name in model.applications:
+        logger.warning("Using existing application: %s", app_name)
+        any_app = model.applications[app_name]
     else:
         any_app = await model.deploy(
             "any-charm",
-            application_name=any_app_name,
+            application_name=app_name,
             channel="beta",
             config={
                 "src-overwrite": json.dumps(any_charm_src_overwrite),
                 "python-packages": "PyJWT",
             },
         )
-        await model.wait_for_idle(apps=[any_app_name], timeout=600)
+        await model.wait_for_idle(apps=[app_name], timeout=600)
     await model.integrate(any_app.name, f"{application.name}:opencti-connector")
     await model.wait_for_idle(status="active", timeout=600)
     yield any_app
+    if not pytestconfig.getoption("--keep-models") and app_name in model.applications:
+        await model.applications[app_name].destroy(force=True, no_wait=True)


### PR DESCRIPTION
Applicable spec: NA

### Overview

Force the teardown of applications during integration tests unless the "--keep-models" parameter was used.

### Rationale

Fix the "never-ending workflow" problem (example [here](https://github.com/canonical/wazuh-server-operator/actions/runs/16768058780/job/47503248570?pr=260#step:73:6418))

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated **NA**
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) **NA**
