### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,1 @@
+rsyslog

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Promote charm](https://github.com/canonical/wazuh-server-operator/actions/workflows/promote_charm.yaml/badge.svg)](https://github.com/canonical/wazuh-server-operator/actions/workflows/promote_charm.yaml)
 [![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
 
-# Wazuh Server Operator
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# Wazuh Server operator
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 A Juju charm deploying and managing Wazuh Server on Kubernetes. Wazuh is an
 open-source XDR and SIEM tool to protect endpoints and cloud workloads. It allows for deployment 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,7 @@ Each revision is versioned by the date of the revision.
 
 ### Added
 
-- Add terraform output for oauth integration.
+- Add terraform output for Open Authorization integration.
 
 ## 2025-07-16
 
@@ -41,8 +41,8 @@ Each revision is versioned by the date of the revision.
 
 ### Added
 
-- Adding `<endpoint>-relation-departed` hooks for opensearch_observer, 
-opencti_connector, wazuh_api and wazuh_peer integrations.
+- Adding `<endpoint>-relation-departed` hooks for `opensearch_observer`, 
+`opencti_connector`, `wazuh_api` and `wazuh_peer` integrations.
 
 ## 2025-06-24
 
@@ -65,7 +65,7 @@ opencti_connector, wazuh_api and wazuh_peer integrations.
 
 ### Updated
 
-- Modified the CI and `pre_run_script.sh` to use Canonical K8s instead of Microk8s.
+- Modified the CI and `pre_run_script.sh` to use Canonical K8s instead of MicroK8s.
 
 ## 2025-06-16
 

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -17,7 +17,7 @@ This shows there are 2 containers:
 
 1. A [Wazuh server](https://wazuh.com/) container, which
 has Wazuh server installed and configured alongside several collectors and
-[filebeat](https://www.elastic.co/beats/filebeat) to ingest and export logs.
+[Filebeat](https://www.elastic.co/beats/filebeat) to ingest and export logs.
 2. A sidecar containing Pebble: a lightweight, API-driven process supervisor that is responsible for
 configuring processes to run in the workload container and controlling those processes
 throughout the workload lifecycle.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -6,7 +6,9 @@ For all use cases and configurations related to the Wazuh product, please refer 
 
 ## Good practices
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### Distribute the Certification Authority (CA) to users
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 The charm deploys Wazuh components with a `self-signed-certificate` CA.
 

--- a/docs/how-to/integrate-with-opencti.md
+++ b/docs/how-to/integrate-with-opencti.md
@@ -1,4 +1,6 @@
-# Integrate with OpenCTI
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# How to integrate with OpenCTI
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 Wazuh allows integration with [OpenCTI](https://charmhub.io/opencti) through the [`opencti-connector` interface](https://charmhub.io/opencti/integrations#opencti-connector). This enables you to create [custom integration scripts](https://documentation.wazuh.com/current/user-manual/manager/integration-with-external-apis.html#custom-integration) that query OpenCTI from Wazuh. 
 
@@ -12,7 +14,9 @@ Wazuh allows integration with [OpenCTI](https://charmhub.io/opencti) through the
 - An existing `wazuh-server` deployment. Refer to the [Wazuh tutorial](https://charmhub.io/wazuh-server/docs/tutorial-getting-started) on how to deploy Wazuh.
 - An existing `opencti` deployment. Refer to the [OpenCTI tutorial](https://charmhub.io/opencti/docs/tutorial-getting-started) on the deployment steps.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## Integrate OpenCTI with Wazuh
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 Create an offer from OpenCTI:
 

--- a/docs/how-to/redeploy.md
+++ b/docs/how-to/redeploy.md
@@ -2,6 +2,8 @@
 
 This guide provides the necessary steps for migrating an existing Wazuh deployment to a new environment.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## Migrate the Indexer data
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 Follow the instructions in [the OpenSearch charm migration documentation](https://github.com/canonical/opensearch-operator/blob/main/docs/how-to/h-migrate-cluster.md) to migrate the data stored in the Wazuh Indexer.

--- a/docs/how-to/test-the-charm.md
+++ b/docs/how-to/test-the-charm.md
@@ -48,7 +48,9 @@ newgrp lxd
 lxd init --auto
 ```
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### Install Canonical Kubernetes
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ```bash
 snap install k8s --classic
@@ -115,7 +117,9 @@ juju bootstrap k8s
 bash -xe ~/wazuh-server-operator/tests/integration/pre_run_script.sh
 ```
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ### (Optional) Install rock dependencies
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 If you anticipate changing the rock container image, follow these additional
 steps:
@@ -167,7 +171,9 @@ cd ~/wazuh-server-operator
 charmcraft pack
 ```
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 #### (Optional) Build the rock
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 If you have not made any changes to the rock, you do not need to rebuild it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
-# Wazuh Server Operator
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# Wazuh Server operator
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 A Juju charm deploying and managing the Wazuh Server on Kubernetes. Wazuh is an
 open-source XDR and SIEM tool to protect endpoints and cloud workloads. It allows for deployment on

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -1,6 +1,6 @@
 # Integrations
 
-### ingress
+### `ingress`
 
 _Interface_: traefik_route  
 _Supported charms_: [Traefik Ingress Operator](https://charmhub.io/traefik-k8s)
@@ -12,7 +12,7 @@ Example ingress integrate command:
 juju integrate wazuh-server traefik-k8s
 ```
 
-### logging
+### `logging`
 
 _Interface_: loki_push_api    
 _Supported charms_: [loki-k8s](https://charmhub.io/loki-k8s)
@@ -26,7 +26,7 @@ Example loki_push_api integrate command:
 juju integrate wazuh-server loki-k8s
 ```
 
-### metrics-endpoint
+### `metrics-endpoint`
 
 _Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape-v0)
 
@@ -41,7 +41,7 @@ Example metrics-endpoint integrate command:
 juju integrate wazuh-server prometheus-k8s
 ```
 
-### opensearch-client
+### `opensearch-client`
 
 _Interface_: opensearch_client  
 _Supported charms_: [OpenSearch](https://charmhub.io/opensearch), [Wazuh Indexer](https://charmhub.io/wazuh-indexer)

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -22,9 +22,9 @@ The [How to manage your deployment](https://documentation.ubuntu.com/juju/3.6/ho
 VM IP in steps that assume you're running locally. To get the IP address of the
 Multipass instance run ```multipass info my-juju-vm```.
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## Set up Canonical Kubernetes
-
-### Install Canonical Kubernetes
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 Install, bootstrap, and check the status of Canonical Kubernetes:
 
@@ -111,7 +111,7 @@ wazuh-server           active      1  wazuh-server              latest/edge     
 
 The deployment is complete when the status is `Active`.
 
-## Clean up the Environment
+## Clean up the environment
 
 Well done! You've successfully completed the Wazuh Server tutorial. To remove the
 model environment you created during this tutorial, use the following command.

--- a/terraform/charm/README.md
+++ b/terraform/charm/README.md
@@ -15,7 +15,7 @@ deployment onto any Kubernetes environment managed by [Juju][Juju].
   the Juju application name.
 - **versions.tf** - Defines the Terraform provider version.
 
-## Using wazuh-server base module in higher level modules
+## Using `wazuh-server` base module in higher level modules
 
 If you want to use `wazuh-server` base module as part of your Terraform module, import it
 like shown below:

--- a/terraform/product/README.md
+++ b/terraform/product/README.md
@@ -1,4 +1,4 @@
-# Terraform Modules
+# Terraform modules
 
 This project contains the [Terraform][Terraform] modules to deploy the 
 [Wazuh server charm][Wazuh server charm] with its dependencies.


### PR DESCRIPTION
Applicable ticket: ISD-3949

### Overview

Run Vale checks locally and fix errors.

### Rationale

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
Either discourse-gatekeeper will update the documentation on Charmhub or I'll do it after the approval of this PR.
Since these are trivial documentation changes, I don't think I need to update the changelog.
