### PR TITLE
bugfix: add "/" to rsync dirpath

### DIFF
--- a/src/wazuh.py
+++ b/src/wazuh.py
@@ -456,12 +456,14 @@ def sync_wazuh_config_files(container: ops.Container) -> None:
     Raises:
         WazuhInstallationError: if an error occurs while pulling the files.
     """
-    source_path = REPO_WAZUH_CONF_PATH
-    if not container.exists(source_path):
-        logger.info("path '%s' does not exist, no files to patch", source_path)
+    source, dest = REPO_WAZUH_CONF_PATH, WAZUH_CONF_PATH
+    if not container.exists(source):
+        logger.info("path '%s' does not exist, no files to patch", source)
         return
+    if container.isdir(source) and source[-1] != "/":
+        source += "/"
     try:
-        logger.info("patching files from %s to %s", source_path, WAZUH_CONF_PATH)
+        logger.info("patching files from %s to %s", source, dest)
         container.exec(
             [
                 "rsync",
@@ -479,8 +481,8 @@ def sync_wazuh_config_files(container: ops.Container) -> None:
                 "--include=etc/shared/**/*.conf",
                 "--include=integrations/***",
                 "--exclude=*",
-                source_path,
-                WAZUH_CONF_PATH,
+                source,
+                dest,
             ],
             timeout=10,
         ).wait_output()
@@ -494,8 +496,8 @@ def sync_wazuh_config_files(container: ops.Container) -> None:
                 "root:wazuh",
                 "--include=ruleset/***",
                 "--exclude=*",
-                source_path,
-                WAZUH_CONF_PATH,
+                source,
+                dest,
             ],
             timeout=10,
         ).wait_output()
@@ -525,7 +527,6 @@ def sync_wazuh_config_files(container: ops.Container) -> None:
         ).wait_output()
     except ops.pebble.ExecError as ex:
         raise WazuhInstallationError from ex
-
 
 def sync_rsyslog_config_files(container: ops.Container) -> None:
     """Sync rsyslog configuration files from the local config repository.


### PR DESCRIPTION
Applicable spec: NA

### Overview

Adds a trailing "/" to the source directory in the `sync_wazuh_config_files` function

### Rationale

Fix minor bug introduced by #260

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated **NA**
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) **NA**
