### PR TITLE
feat(docs): Evolve and standardize the documentation workflow

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,1 +1,0 @@
-rsyslog

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,11 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  docs-checks:
+    uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
+    secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
     with:
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
-      vale-style-check: true
+      vale-style-check: false

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,15 @@ __pycache__/
 *.egg-info/
 */*.rock
 *.rock
+
+# BEGIN VALE WORKFLOW IGNORE
+.vale/styles/*
+!.vale/styles/local
+!.vale/styles/config/
+
+.vale/styles/config/*
+!.vale/styles/config/vocabularies/
+
+.vale/styles/config/vocabularies/*
+!.vale/styles/config/vocabularies/local
+# END VALE WORKFLOW IGNORE

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,11 @@
+; Copyright 2025 Canonical Ltd.
+; See LICENSE file for licensing details.
+
+StylesPath = .vale/styles
+
+Packages = https://github.com/canonical/platform-engineering-vale-package/releases/download/latest/pfe-vale.zip
+
+Vocab = PFE, local
+
+[*]
+BasedOnStyles = PFE

--- a/.vale/styles/config/vocabularies/local/accept.txt
+++ b/.vale/styles/config/vocabularies/local/accept.txt
@@ -1,0 +1,2 @@
+Filebeat
+rsyslog

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Top-level Makefile
+# Delegates targets to Makefile.docs
+
+# ==============================================================================
+# Macros
+# ==============================================================================
+
+# Colors
+NO_COLOR=\033[0m
+CYAN_COLOR=\033[0;36m
+YELLOW_COLOR=\033[0;93m
+RED_COLOR=\033[0;91m
+
+msg = @printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
+errmsg = @printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+
+# ==============================================================================
+# Core
+# ==============================================================================
+
+include Makefile.docs
+
+.PHONY: help 
+help: _list-targets ## Prints all available targets
+
+.PHONY: _list-targets
+_list-targets: ## This collects and prints all targets, ignore internal commands
+	$(call msg,Available targets:)
+	@awk -F'[:#]' '                                               \
+		/^[a-zA-Z0-9._-]+:([^=]|$$)/ {                            \
+			target = $$1;                                         \
+			comment = "";                                         \
+			if (match($$0, /## .*/))                              \
+				comment = substr($$0, RSTART + 3);                \
+			if (target != ".PHONY" && target !~ /^_/ && !seen[target]++) \
+				printf "  make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target, comment;    \
+		}' $(MAKEFILE_LIST) | sort

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,0 +1,74 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Minimal makefile for documentation
+#
+
+# Vale settings
+VALE_DIR ?= .vale
+PRAECEPTA_CONFIG 	?= .vale.ini
+DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+
+HAS_VALE			:= $(shell command -v vale;)
+HAS_LYCHEE			:= $(shell command -v lychee;)
+
+# ==============================================================================
+# Docs Targets
+# ==============================================================================
+
+.PHONY: docs-check
+docs-check: vale lychee ## Run all Docs checks
+
+.PHONY: docs-clean
+docs-clean: vale-clean
+
+# ==============================================================================
+# Dependency Check Targets
+# ==============================================================================
+
+.PHONY: .check-vale
+.check-vale:
+ifndef HAS_VALE
+	$(call errmsg,'vale' is not installed. Please install it first) \
+	exit 1;
+endif
+
+.PHONY: .check-lychee
+.check-lychee:
+ifndef HAS_LYCHEE
+	$(call errmsg,'lychee' is not installed. Please install it first) \
+	exit 1;
+endif
+
+
+# ==============================================================================
+# Main Vale Targets
+# ==============================================================================
+
+.PHONY: vale-sync
+vale-sync: ## Download and install external Vale configuration sources
+	$(call msg,--- Syncing Vale styles... ---)
+	@vale sync
+
+.PHONY: vale
+vale: .check-vale vale-sync ## Run Vale checks on docs
+	$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
+	@vale --config=$(PRAECEPTA_CONFIG) $(DOCS_FILES)
+
+# ==============================================================================
+# Main Lychee Targets
+# ==============================================================================
+
+.PHONY: lychee
+lychee: .check-lychee ## Run Lychee checks on docs
+	$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
+	@lychee $(DOCS_FILES)
+
+# ==============================================================================
+# Helper Targets
+# ==============================================================================
+
+.PHONY: vale-clean
+vale-clean:
+	$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
+	@git clean -dfX $(VALE_DIR)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For information about how to deploy, integrate, and manage this charm, see the O
 
 ## Get started
 
-You can follow the tutorial [here](https://charmhub.io/wazuh-server/docs/getting-started).
+You can follow the tutorial [here](https://charmhub.io/wazuh-server/docs/tutorial-getting-started).
 
 ## Integrations
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-08-20
+
+### Added
+
+- New documentation checks workflow.
+
 ## 2025-07-22
 
 ### Added

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -26,7 +26,7 @@ throughout the workload lifecycle.
 
 We use [Rockcraft](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/)
 to build the OCI image for Wazuh server.
-The image is defined in [Wazuh server rock](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml) and is published to [Charmhub](https://charmhub.io/), the official repository
+The image is defined in [Wazuh server rock](https://github.com/canonical/wazuh-server-operator/blob/main/rock/rockcraft.yaml) and is published to [Charmhub](https://charmhub.io/), the official repository
 of charms.
 This is done by publishing a resource to Charmhub as described in the
 [Charmcraft how-to guides](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/howto/manage-charms/#publish-a-charm-on-charmhub).
@@ -62,7 +62,7 @@ Rel(filesystem, wazuh-server,"")
 
 ```
 
-The workload that this container is running is defined in the [Wazuh server rock](https://github.com/canonical/wazuh-server-operator/tree/main/rockcraft.yaml).
+The workload that this container is running is defined in the [Wazuh server rock](https://github.com/canonical/wazuh-server-operator/blob/main/rock/rockcraft.yaml).
 
 
 ## Storage
@@ -77,7 +77,7 @@ The `src/charm.py` is the default entry point for a charm and has the
 CharmBase is the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops)
 (Python framework for developing charms).
 
-See more information in [Charm](https://juju.is/docs/sdk/constructs#heading--charm).
+See more information in [Charm](https://documentation.ubuntu.com/juju/3.6/reference/charm/).
 
 The `__init__` method guarantees that the charm observes all events relevant to
 its operation and handles them.

--- a/docs/how-to/deploy-to-production.md
+++ b/docs/how-to/deploy-to-production.md
@@ -18,7 +18,7 @@ Open network accesses:
 
 ## Deploy the project
 
-The full stack can be deployed using the terraform module hosted at [https://github.com/canonical/wazuh-server-operator/terraform/product/](https://github.com/canonical/wazuh-server-operator/terraform/product/).
+The full stack can be deployed using the terraform module hosted at [https://github.com/canonical/wazuh-server-operator/tree/main/terraform/product](https://github.com/canonical/wazuh-server-operator/tree/main/terraform/product).
 
 A typical deployment would be configured like this:
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ For information about how to deploy, integrate, and manage this charm, see the O
 
 | | |
 |--|--|
-|  [Tutorials](https://charmhub.io/wazuh-server/docs/tutorial)</br>  Get started - a hands-on introduction to using the Charmed Wazuh Server operator for new users </br> |  [How-to guides](https://charmhub.io/wazuh-server/docs/how-to-contribute) </br> Step-by-step guides covering key operations and common tasks |
+|  [Tutorials](https://charmhub.io/wazuh-server/docs/tutorial-getting-started)</br>  Get started - a hands-on introduction to using the Charmed Wazuh Server operator for new users </br> |  [How-to guides](https://charmhub.io/wazuh-server/docs/how-to-contribute) </br> Step-by-step guides covering key operations and common tasks |
 | [Reference](https://charmhub.io/wazuh-server/docs/reference-actions) </br> Technical information - specifications, APIs, architecture | [Explanation](https://charmhub.io/wazuh-server/docs/explanation-charm-architecture) </br> Concepts - discussion and clarification of key topics  |
 
 ## Contributing to this documentation

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -28,7 +28,7 @@ juju integrate wazuh-server loki-k8s
 
 ### `metrics-endpoint`
 
-_Interface_: [prometheus_scrape](https://charmhub.io/interfaces/prometheus_scrape-v0)
+_Interface_: [prometheus_scrape](https://charmhub.io/integrations/prometheus_scrape)
 
 _Supported charms_: [prometheus-k8s](https://charmhub.io/prometheus-k8s)
 


### PR DESCRIPTION
### Description:

This PR builds upon our team's commitment to high-quality documentation by formalizing and standardizing our style-checking workflow.

It evolves our existing efforts of checking against the Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`) into a fully integrated, **`vale-native`** process. This more streamlined approach unlocks powerful new capabilities for the team, including:
* Seamless integration with the official **Vale GitHub Action** for automated checks via a new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml)
* Simple and consistent **`make` targets** for reliable local validation, in line with CI validation.
* The ability to use **IDE extensions** for real-time feedback while writing.

---
### Key Changes

* **CI Automation:**
    * Leveraging our new [docs workflow](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/docs.yaml) to run on every pull request to:
        * Lint all documentation using **Vale**.
        * Check for **broken links**.

* **Layered Vale Configuration:**
    * **Project-Level:** A local `.vale.ini` and `accept.txt` allow for project-specific vocabulary and rule overrides.
    * **Team-Level:** The configuration inherits from our new central [platform-engineering-vale](https://github.com/canonical/platform-engineering-vale-package) package, allowing us to manage team-wide vocabulary and rules in one place.
    * **Company-Level:** The team package is configured to enherit the official Canonical [Documentation Style Guide](https://github.com/canonical/documentation-style-guide) (`praecepta`), ensuring we stay aligned with broader company standards.

* **Improved Local Experience:**
    * A new `Makefile` and `Makefile.docs` provide simple targets for authors to validate their work locally before pushing.
    * Running `make vale`, `make lychee` or `make docs-check` locally is now **identical** to the checks run in CI, eliminating surprises.

### Interested in adding this workflow to a project?

You can add this entire standardized workflow to your own repository with a single command.

First, ensure you are in the root of your project on a **new branch** (not `main`), then run:

```bash
bash <(curl -sSL "https://raw.githubusercontent.com/srbouffard/vale-workflow-template/main/bootstrap.sh?$(date +%s)")
```

The script is interactive and will guide you through the setup.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
