### PR TITLE
skip integration tests if src hasn't changed

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -2,6 +2,14 @@ name: Integration tests
 
 on:
   pull_request:
+    paths:
+      - 'lib/**'
+      - 'rock/**'
+      - 'src/**'
+      - 'tests/**'
+      - '*.yaml'
+      - '*.txt'
+      - '*.tsv'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Applicable spec: NA

### Overview

Skip integration tests if no source files impacting the integration tests have changed.
Takes an 'allow-list' approach that runs integration tests IF a PR has affected one or more of the listed paths.
[docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#example-including-paths)

### Rationale

Skip the (frequently realized) possibility of hours-long workflow runs on (for example) docs PRs.

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

NA
