### PR TITLE
DRAFT: Wazuh-Charm Error Alerts

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -38,6 +38,7 @@ WAZUH_PEER_RELATION_NAME = "wazuh-peers"
 WAZUH_SERVICE_NAME = "wazuh"
 FILEBEAT_SERVICE_NAME = "filebeat"
 RSYSLOG_SERVICE_NAME = "rsyslog"
+RSYSLOG_DEBUG_LOG_PATH = "/var/log/rsyslog.log"
 
 
 class WazuhServerCharm(CharmBaseWithState):
@@ -379,6 +380,12 @@ class WazuhServerCharm(CharmBaseWithState):
             environment["NO_PROXY"] = proxy.no_proxy
         if not self.state:
             return {}
+ 
+
+        # RSYSLOG ENVIRONMENT 
+        # Set RSYSLOG_DEBUGLOG to capture all debug/pebble output to the specified file
+        environment["RSYSLOG_DEBUGLOG"] = RSYSLOG_DEBUG_LOG_PATH
+
         return {
             "summary": "wazuh manager layer",
             "description": "pebble config layer for wazuh-manager",
@@ -402,6 +409,7 @@ class WazuhServerCharm(CharmBaseWithState):
                     "summary": "rsyslog",
                     "command": "rsyslogd -n -f /etc/rsyslog.conf",
                     "startup": "enabled",
+                    "environment": environment,
                 },
             },
             "checks": {

--- a/src/loki_alert_rules/filebeat_error_found.rule
+++ b/src/loki_alert_rules/filebeat_error_found.rule
@@ -1,10 +1,11 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 alert: WazuhFilebeatErrorFound
-expr: rate({%%juju_topology%%, pebble_service="filebeat"} |= " - ERROR - "[5m]) > 0
+expr: rate({%%juju_topology%%} |~ "(?i)error" |~ "(?i)filebeat") > 0
 for: 5m
 labels:
   severity: error
 annotations:
   summary: Filebeat errors detected.
-  description: This alert is triggered when Filebeat logs an error level message in the last 5 minutes.
+  description: This alert is triggered when the filebeat a error level message in the last 5 minutes.
+

--- a/src/loki_alert_rules/filebeat_service_error_found.rule
+++ b/src/loki_alert_rules/filebeat_service_error_found.rule
@@ -1,0 +1,10 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+alert: WazuhFilebeatServiceErrorFound
+expr: rate({%%juju_topology%%, pebble_service="filebeat"} |= " - ERROR - "[5m]) > 0
+for: 5m
+labels:
+  severity: error
+annotations:
+  summary: Filebeat service errors detected.
+  description: This alert is triggered when the pebble-managed Filebeat service logs an error level message in the last 5 minutes.

--- a/src/loki_alert_rules/rsyslog_error_found.rule
+++ b/src/loki_alert_rules/rsyslog_error_found.rule
@@ -1,0 +1,10 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+alert: WazuhRsyslogErrorFound
+expr: rate({%%juju_topology%%} |~ "(?i)error" |~ "(?i)rsyslog") > 0
+for: 5m
+labels:
+  severity: error
+annotations:
+  summary: Rsyslog errors detected.
+  description: This alert is triggered when Rsyslog logs an error level message in the last 5 minutes.

--- a/src/loki_alert_rules/rsyslog_service_error_found.rule
+++ b/src/loki_alert_rules/rsyslog_service_error_found.rule
@@ -1,10 +1,10 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-alert: WazuhRsyslogErrorFound
+alert: WazuhRsyslogServiceErrorFound
 expr: rate({%%juju_topology%%, pebble_service="rsyslog"} |= " - ERROR - "[5m]) > 0
 for: 5m
 labels:
   severity: error
 annotations:
   summary: Rsyslog errors detected.
-  description: This alert is triggered when Rsyslog logs an error level message in the last 5 minutes.
+  description: This alert is triggered when the pebble-managed Rsyslog service logs an error level message in the last 5 minutes.

--- a/src/loki_alert_rules/wazuh_error_found.rule
+++ b/src/loki_alert_rules/wazuh_error_found.rule
@@ -1,10 +1,10 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 alert: WazuhErrorFound
-expr: rate({%%juju_topology%%, pebble_service="wazuh"} |= " - ERROR - "[5m]) > 0
+expr: rate({%%juju_topology%%} |~ "(?i)error" |~ "(?i)wazuh") > 0
 for: 5m
 labels:
   severity: error
 annotations:
   summary: Wazuh errors detected.
-  description: This alert is triggered when Wazuh logs an error level message in the last 5 minutes.
+  description: This alert is triggered when the Wazuh charm logs a error level message in the last 5 minutes.

--- a/src/loki_alert_rules/wazuh_service_error_found.rule
+++ b/src/loki_alert_rules/wazuh_service_error_found.rule
@@ -1,0 +1,12 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+alert: WazuhServiceErrorFound
+expr: rate({
+%%juju_topology%%, pebble_service="wazuh"} 
+|= " - ERROR - "[5m]) > 0 
+for: 5m
+labels:
+  severity: error
+annotations:
+  summary: Wazuh errors detected.
+  description: This alert is triggered when the pebble-managed Wazuh service logs an error level message in the last 5 minutes.

--- a/src/observability.py
+++ b/src/observability.py
@@ -8,12 +8,25 @@ import ops
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from pathlib import Path
 
 import wazuh
 
-LOG_PATHS = [(wazuh.LOGS_PATH / "*.log").absolute().as_posix()]
-PROMETHEUS_PORT = 5000
+RSYSLOG_DEBUG_LOG_PATH = "/var/log/rsyslog.log" 
 
+
+LOG_PATHS = [
+    # 1. Wazuh main application logs
+    (wazuh.LOGS_PATH / "*.log").absolute().as_posix(),
+    
+    # 2. Filebeat Logs (current and rotated files)
+    (Path("/var/log/filebeat") / "filebeat").absolute().as_posix(),  
+    (Path("/var/log/filebeat") / "filebeat.*").absolute().as_posix(),
+
+    # 3. Rsyslog Logs
+    Path(RSYSLOG_DEBUG_LOG_PATH).absolute().as_posix(),
+]
+PROMETHEUS_PORT = 5000
 
 class Observability:  # pylint: disable=too-few-public-methods
     """A class representing the observability stack for Wazuh application."""
@@ -47,3 +60,7 @@ class Observability:  # pylint: disable=too-few-public-methods
                 },
             },
         )
+
+
+
+

--- a/src/prometheus_alert_rules/wazuh_server.rule
+++ b/src/prometheus_alert_rules/wazuh_server.rule
@@ -20,13 +20,13 @@ groups:
       summary: Invalid Wazuh server configuration (instance {{ $labels.instance }})
       description: "Wazuh server configuration is invalid. Invalid configuration might have been pulled from the repository.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
   - alert: WazuhServerNoEventsReceived
-    expr: rate(analysisd_stats{analysisd_stats="events_received"}[5m]) == 0
+    expr: rate(analysisd_stats{analysisd_stats="events_received"}[5m]) == 50
     for: 0m
     labels:
       severity: critical
     annotations:
-      summary: No events have been received for the last 5 minutes (instance {{ $labels.instance }})
-      description: "Wazuh server has not received any events for the last 5 minutes. The instance might not be reachable.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+      summary: No events have been received for the last 5 minutes asides the internal Wazuh log events (instance {{ $labels.instance }})
+      description: "Wazuh server has not received any events for the last 5 minutes asides those it generates itself. The instance might not be reachable.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
   - alert: WazuhServerNoEventsProcessed
     expr: rate(analysisd_stats{analysisd_stats="events_processed"}[5m]) == 0
     for: 0m


### PR DESCRIPTION
DRAFT: Modified the observability.py and charm.py codes to scrape rsyslog, filebeat logs, and created loki alerts to alert on these

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
