### PR TITLE
Use only the master node as backend for API and agent register

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -440,6 +440,7 @@ class CharmBaseWithState(ops.CharmBase, ABC):
     """CharmBase than can build a CharmState.
 
     Attrs:
+        master_fqdn: the FQDN for unit 0.
         state: the charm state.
         units_fqdns: the charm units' FQDNs.
     """
@@ -459,4 +460,12 @@ class CharmBaseWithState(ops.CharmBase, ABC):
         """Retrieve the FQDNs of the charm units.
 
         Returns: a list of FQDNs.
+        """
+
+    @property
+    @abstractmethod
+    def master_fqdn(self) -> list[str]:
+        """Get the FQDN for the unit 0.
+
+        Returns: the FQDN for the unit 0.
         """

--- a/tests/unit/test_certificates_observer.py
+++ b/tests/unit/test_certificates_observer.py
@@ -28,6 +28,7 @@ class ObservedCharm(state.CharmBaseWithState):
     """Class for requirer charm testing.
 
     Attrs:
+        master_fqdn: the FQDN for unit 0.
         state: the charm state.
         units_fqdns: the charm units' FQDNs.x
     """
@@ -54,6 +55,14 @@ class ObservedCharm(state.CharmBaseWithState):
         Returns: a list of FQDNs.
         """
         return []
+
+    @property
+    def master_fqdn(self) -> str:
+        """Get the FQDN for the unit 0.
+
+        Returns: the FQDN for the unit 0.
+        """
+        return "host1.example"
 
     @property
     def state(self) -> state.State | None:

--- a/tests/unit/test_traefik_route_observer.py
+++ b/tests/unit/test_traefik_route_observer.py
@@ -29,6 +29,7 @@ class ObservedCharm(state.CharmBaseWithState):
     """Class for requirer charm testing.
 
     Attrs:
+        master_fqdn: the FQDN for unit 0.
         state: the charm state.
         units_fqdns: the charm units' FQDNs.
     """
@@ -54,6 +55,14 @@ class ObservedCharm(state.CharmBaseWithState):
         Returns: a list of FQDNs.
         """
         return ["host1.example", "host2.example"]
+
+    @property
+    def master_fqdn(self) -> str:
+        """Get the FQDN for the unit 0.
+
+        Returns: the FQDN for the unit 0.
+        """
+        return "host1.example"
 
     @property
     def state(self) -> state.State | None:
@@ -150,7 +159,6 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                         "loadBalancer": {
                             "servers": [
                                 {"address": "host1.example:1515"},
-                                {"address": "host2.example:1515"},
                             ],
                             "terminationDelay": -1,
                         }
@@ -159,7 +167,6 @@ def test_on_traefik_route_relation_joined_when_leader(monkeypatch: pytest.Monkey
                         "loadBalancer": {
                             "servers": [
                                 {"address": f"host1.example:{wazuh.API_PORT}"},
-                                {"address": f"host2.example:{wazuh.API_PORT}"},
                             ],
                             "terminationDelay": -1,
                         }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Use only the master node as backend for API and agent register and exclude workers


### Rationale

<!-- The reason the change is needed -->
* Match example configuration from Wazuh for enrolling agents
* Avoid issues with the API

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
