### PR TITLE
chore: migrate CI to charm-ci / opcli

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Integration tests
 
 on:
@@ -8,36 +11,22 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+  integration-test:
+    uses: canonical/charm-ci/.github/workflows/integration-test.yml@main
     secrets: inherit
     permissions:
       contents: read
       packages: write
-    with:
-      channel: 1.33-classic/stable
-      extra-arguments: |
-        --kube-config=~/.kube/config
-      juju-channel: 3/stable
-      pre-run-script: |
-        -c "chmod +x tests/integration/pre_run_script.sh
-        ./tests/integration/pre_run_script.sh"
-      trivy-fs-enabled: true
-      trivy-image-config: "trivy.yaml"
-      self-hosted-runner: true
-      self-hosted-runner-label: "xlarge"
-      tmate-timeout: 20
-      use-canonical-k8s: true
-      provider: 'k8s'
-      with-uv: true
+      actions: read
   allure-report:
     if: ${{ !cancelled() && github.event_name == 'schedule' }}
     needs:
-    - integration-tests
+    - integration-test
     uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,8 +25,20 @@ jobs:
       contents: read
       packages: write
       actions: read
-  allure-report:
-    if: ${{ !cancelled() && github.event_name == 'schedule' }}
+  required_status_checks:
+    name: Required Integration Test Status Checks
+    runs-on: ubuntu-latest
     needs:
-    - integration-test
-    uses: canonical/operator-workflows/.github/workflows/allure_report.yaml@main
+      - integration-test
+    if: always() && !cancelled()
+    timeout-minutes: 5
+    steps:
+      - name: Check integration-test status
+        run: |
+          RESULT="${{ needs.integration-test.result }}"
+          if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then
+            exit 0
+          else
+            echo "integration-test failed with status: $RESULT"
+            exit 1
+          fi

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Publish to edge
 
 on:
@@ -8,10 +11,10 @@ on:
 
 jobs:
   publish-to-edge:
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@main
     permissions:
-      actions: read
       contents: write
+      actions: read
     secrets: inherit
     with:
       channel: 4.11/edge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,15 +1,33 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: Tests
 
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    name: Unit tests
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    secrets: inherit
-    with:
-      vale-style-check: false
-      with-uv: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Run lint
+        run: uv run --group lint tox -e lint
+
+      - name: Run static analysis
+        run: uv run --group static tox -e static
+
+      - name: Run unit tests
+        run: uv run --group unit tox -e unit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,33 +1,15 @@
-# Copyright 2025 Canonical Ltd.
-# See LICENSE file for licensing details.
-
 name: Tests
 
 on:
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   unit-tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     permissions:
       contents: read
       pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Run lint
-        run: uv run --group lint tox -e lint
-
-      - name: Run static analysis
-        run: uv run --group static tox -e static
-
-      - name: Run unit tests
-        run: uv run --group unit tox -e unit
+    secrets: inherit
+    with:
+      vale-style-check: false
+      with-uv: true

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -1,0 +1,17 @@
+version: 1
+rocks:
+- name: wazuh-server
+  rockcraft-yaml: rock/rockcraft.yaml
+  platforms:
+  - arch: amd64
+charms:
+- name: wazuh-server
+  charmcraft-yaml: charmcraft.yaml
+  channel: 4.11/edge
+  resources:
+    wazuh-server-image:
+      type: oci-image
+      rock: wazuh-server
+  platforms:
+  - arch: amd64
+snaps: []

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -1,3 +1,5 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
 version: 1
 rocks:
 - name: wazuh-server

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -2,9 +2,6 @@
 # See LICENSE file for licensing details.
 juju:
   channel: 3/stable
-  model-defaults:
-    test-mode: "true"
-    automatically-retry-hooks: "false"
 
 providers:
   microk8s:
@@ -15,6 +12,9 @@ providers:
       - dns
       - rbac
       - registry
+    model-defaults:
+      test-mode: "true"
+      automatically-retry-hooks: "false"
   lxd:
     enable: true
     bootstrap: true
@@ -26,4 +26,3 @@ host:
   snaps:
     rockcraft:
     charmcraft:
-

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -12,6 +12,7 @@ providers:
       - dns
       - rbac
       - registry
+      - metallb:10.64.140.43-10.64.140.49
     model-defaults:
       test-mode: "true"
       automatically-retry-hooks: "false"

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,21 @@
+juju:
+  channel: 3/stable
+  model-defaults:
+    test-mode: "true"
+    automatically-retry-hooks: "false"
+
+providers:
+  microk8s:
+    enable: true
+    bootstrap: true
+    addons:
+      - hostpath-storage
+      - dns
+      - rbac
+      - registry
+
+host:
+  snaps:
+    rockcraft:
+    charmcraft:
+

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,3 +1,5 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
 juju:
   channel: 3/stable
   model-defaults:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -15,6 +15,12 @@ providers:
       - dns
       - rbac
       - registry
+  lxd:
+    enable: true
+    bootstrap: true
+    model-defaults:
+      test-mode: "true"
+      automatically-retry-hooks: "false"
 
 host:
   snaps:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -12,7 +12,7 @@ providers:
       - dns
       - rbac
       - registry
-      - metallb:10.64.140.43-10.64.140.49
+      - metallb:10.43.45.1-10.43.45.14
     model-defaults:
       test-mode: "true"
       automatically-retry-hooks: "false"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ integration = [
   "allure-pytest>=2.8.18",
   "allure-pytest-collection-report @ git+https://github.com/canonical/data-platform-workflows@v24.0.0#subdirectory=python/pytest_plugins/allure_pytest_collection_report",
   "juju",
+  "opcli @ git+https://github.com/canonical/charm-ci.git ; python_version >= '3.12'",
   "pyjwt",
   "pytest",
   "pytest-asyncio",

--- a/spread.yaml
+++ b/spread.yaml
@@ -31,5 +31,6 @@ integration-suites:
       sudo -iu ubuntu bash "$SPREAD_PATH/tests/integration/pre_run_script.sh"
     pytest-arguments-template: |
       --controller=concierge-microk8s
+      --model=testing
       --kube-config=~/.kube/config
       --keep-models

--- a/spread.yaml
+++ b/spread.yaml
@@ -30,5 +30,6 @@ integration-suites:
     prepare: |
       sudo -iu ubuntu bash "$SPREAD_PATH/tests/integration/pre_run_script.sh"
     pytest-arguments-template: |
+      --controller=concierge-microk8s
       --kube-config=~/.kube/config
       --keep-models

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,32 @@
+project: wazuh-server-operator
+path: /home/ubuntu/proj
+kill-timeout: 120m
+warn-timeout: 5m
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+    - ubuntu-24.04:
+        runner: [self-hosted, self-hosted-linux-amd64-noble-xlarge]
+        cpu: 4
+        memory: 16
+        disk: 50
+environment:
+  CONCIERGE: '$(HOST: echo "${CONCIERGE:-concierge.yaml}")'
+  OPCLI_GIT_REF: '$(HOST: echo "${OPCLI_GIT_REF:-main}")'
+exclude:
+- .git
+- .tox
+- .venv
+- .*_cache
+integration-suites:
+  tests/integration/:
+    summary: integration tests
+    working-dir: ./
+    backends:
+    - integration-test
+    prepare: |
+      sudo -iu ubuntu bash "$SPREAD_PATH/tests/integration/pre_run_script.sh"
+    pytest-arguments-template: |
+      --kube-config=~/.kube/config
+      --keep-models

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,3 +1,5 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
 project: wazuh-server-operator
 path: /home/ubuntu/proj
 kill-timeout: 120m

--- a/spread.yaml
+++ b/spread.yaml
@@ -9,7 +9,7 @@ backends:
     type: integration-test
     systems:
     - ubuntu-24.04:
-        runner: [self-hosted, self-hosted-linux-amd64-noble-xlarge]
+        runner: [ubuntu-24.04]
         cpu: 4
         memory: 16
         disk: 50
@@ -34,3 +34,4 @@ integration-suites:
       --model=testing
       --kube-config=~/.kube/config
       --keep-models
+      --single-node-indexer

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,7 +3,7 @@
 project: wazuh-server-operator
 path: /home/ubuntu/proj
 kill-timeout: 120m
-warn-timeout: 5m
+warn-timeout: 1m
 backends:
   integration-test:
     type: integration-test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,5 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
-    parser.addoption("--charm-file", action="store")
     parser.addoption("--kube-config", action="store", default="~/.kube/config")
-    parser.addoption("--wazuh-server-image", action="store")
     parser.addoption("--single-node-indexer", action="store_true")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,6 @@ import asyncio
 import itertools
 import json
 import logging
-import os.path
 import secrets
 import typing
 from pathlib import Path
@@ -74,15 +73,6 @@ async def machine_model_fixture(
         model = await machine_controller.add_model(machine_model_name)
     await model.connect(f"localhost:admin/{model.name}")
     await model.set_config(MACHINE_MODEL_CONFIG)
-    logger.info("Using VM for deployment until LXD+SNAP+Kernel 6.14 bug is fixed")
-    await model.set_constraints(
-        {
-            "virt-type": "virtual-machine",
-            "mem": 4096,
-            "root-disk": 15000,
-            "cores": 4,
-        }
-    )
     yield model
     await model.disconnect()
 
@@ -228,21 +218,11 @@ async def wazuh_dashboard_fixture(
         )
 
 
-@pytest_asyncio.fixture(scope="module", name="charm")
-async def charm_fixture(pytestconfig: pytest.Config) -> str:
-    """Get value from parameter charm-file."""
-    charm = pytestconfig.getoption("--charm-file")
-    assert charm, "--charm-file must be set"
-    if not os.path.exists(charm):
-        logger.info("Using parent directory for charm file")
-        charm = os.path.join("..", charm)
-    return charm
-
-
 # pylint: disable=too-many-arguments, too-many-positional-arguments
 @pytest_asyncio.fixture(scope="module", name="application")
 async def application_fixture(
-    charm: str,
+    charm_path: str,
+    resource_images: dict[str, str],
     machine_model: Model,
     model: Model,
     k8s_self_signed_certificates: Application,
@@ -252,9 +232,6 @@ async def application_fixture(
 ) -> typing.AsyncGenerator[Application, None]:
     """Deploy the charm."""
     # Deploy the charm and wait for active/idle status
-    resources = {
-        "wazuh-server-image": pytestconfig.getoption("--wazuh-server-image"),
-    }
     wazuh_server_app = "wazuh-server"
     if pytestconfig.getoption("--no-deploy") and wazuh_server_app in model.applications:
         logger.warning("Using existing application: %s", wazuh_server_app)
@@ -262,12 +239,12 @@ async def application_fixture(
         return
 
     await model.deploy(
-        f"./{charm}",
+        f"./{charm_path}",
         config={
             "logs-ca-cert": (Path(__file__).parent / "certs/ca.crt").read_text(),
             "enable-vulnerability-detection": False,
         },
-        resources=resources,
+        resources=resource_images,
         trust=True,
     )
     application = model.applications[wazuh_server_app]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -239,7 +239,7 @@ async def application_fixture(
         return
 
     await model.deploy(
-        f"./{charm_path}",
+        charm_path,
         config={
             "logs-ca-cert": (Path(__file__).parent / "certs/ca.crt").read_text(),
             "enable-vulnerability-detection": False,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,7 @@ async def model_fixture(ops_test: OpsTest) -> Model:
 async def machine_controller_fixture() -> typing.AsyncGenerator[Controller, None]:
     """The lxd controller."""
     controller = Controller()
-    await controller.connect_controller("localhost")
+    await controller.connect_controller("concierge-lxd")
     yield controller
     await controller.disconnect()
     await asyncio.sleep(1)
@@ -71,7 +71,7 @@ async def machine_model_fixture(
         model = await machine_controller.get_model(machine_model_name)
     else:
         model = await machine_controller.add_model(machine_model_name)
-    await model.connect(f"localhost:admin/{model.name}")
+    await model.connect(f"concierge-lxd:admin/{model.name}")
     await model.set_config(MACHINE_MODEL_CONFIG)
     yield model
     await model.disconnect()
@@ -249,7 +249,7 @@ async def application_fixture(
     )
     application = model.applications[wazuh_server_app]
     await model.integrate(
-        f"localhost:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
+        f"concierge-lxd:admin/{opensearch_provider.model.name}.{opensearch_provider.name}",
         application.name,
     )
     await model.integrate(k8s_self_signed_certificates.name, application.name)

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -8,31 +8,9 @@
 
 set -euo pipefail
 
-TESTING_MODEL="$(juju switch)"
-
-# Bootstrap the localhost (LXD) controller only if it doesn't already exist.
-if ! juju show-controller localhost &>/dev/null; then
-  echo "bootstrapping lxd juju controller"
-  sudo lxd init --auto || true
-  # Disable IPv6 on the LXD bridge so all containers get IPv4 addresses only.
-  sudo lxc network set lxdbr0 ipv6.address none ipv6.dhcp false || true
-  juju bootstrap localhost localhost
-else
-  echo "lxd juju controller already exists, skipping bootstrap"
-fi
-
-echo "Switching to testing model"
-juju switch "$TESTING_MODEL"
-
 # https://charmhub.io/opensearch/docs/t-set-up#set-parameters-on-the-host-machine
-# Append only if not already set.
-if ! grep -q "vm.max_map_count=262144" /etc/sysctl.conf; then
-  sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
-vm.max_map_count=262144
-vm.swappiness=0
-net.ipv4.tcp_retries2=5
-fs.file-max=1048576
-EOT
-fi
-
-sudo sysctl -p
+# Applied temporarily — no reboot expected.
+sudo sysctl -w vm.max_map_count=262144
+sudo sysctl -w vm.swappiness=0
+sudo sysctl -w net.ipv4.tcp_retries2=5
+sudo sysctl -w fs.file-max=1048576

--- a/tests/integration/pre_run_script.sh
+++ b/tests/integration/pre_run_script.sh
@@ -3,29 +3,36 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# Pre-run script for integration test operator-workflows action.
-# https://github.com/canonical/operator-workflows/blob/main/.github/workflows/integration_test.yaml
-
+# Pre-run script for integration tests.
 # OpenSearch charms are deployed on lxd and Wazuh Server charm is deployed on Canonical K8S.
 
 set -euo pipefail
 
 TESTING_MODEL="$(juju switch)"
 
-# lxd should be install and init by a previous step in integration test action.
-echo "bootstrapping lxd juju controller"
-juju bootstrap localhost localhost
+# Bootstrap the localhost (LXD) controller only if it doesn't already exist.
+if ! juju show-controller localhost &>/dev/null; then
+  echo "bootstrapping lxd juju controller"
+  sudo lxd init --auto || true
+  # Disable IPv6 on the LXD bridge so all containers get IPv4 addresses only.
+  sudo lxc network set lxdbr0 ipv6.address none ipv6.dhcp false || true
+  juju bootstrap localhost localhost
+else
+  echo "lxd juju controller already exists, skipping bootstrap"
+fi
 
 echo "Switching to testing model"
 juju switch "$TESTING_MODEL"
 
 # https://charmhub.io/opensearch/docs/t-set-up#set-parameters-on-the-host-machine
-sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
+# Append only if not already set.
+if ! grep -q "vm.max_map_count=262144" /etc/sysctl.conf; then
+  sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
 vm.max_map_count=262144
 vm.swappiness=0
 net.ipv4.tcp_retries2=5
 fs.file-max=1048576
 EOT
+fi
 
 sudo sysctl -p
-

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -145,7 +145,7 @@ async def test_cluster_api_credentials(
         )
         retries = 5
         while retries:
-            url = (f"https://{ip}:55000/security/user/authenticate",)
+            url = f"https://{ip}:55000/security/user/authenticate"
             response = requests.get(  # nosec
                 url,
                 auth=("wazuh", password),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,6 +5,7 @@
 
 """Integration tests."""
 
+import asyncio
 import logging
 import secrets
 import ssl
@@ -39,13 +40,13 @@ PEBBLE_EXEC = f"PEBBLE_SOCKET={PEBBLE_SOCKET} /charm/bin/pebble exec"
 
 
 @pytest.mark.abort_on_fail
-async def test_api(model: Model, application: Application):
+async def test_api(model: Model, application: Application, traefik: Application):
     """
     Arrange: deploy the charm together with related charms.
     Act: do nothing.
     Assert: the default credentials are no longer valid for the API.
     """
-    await model.wait_for_idle(apps=[application.name], status="active", timeout=1400)
+    await model.wait_for_idle(apps=[application.name, traefik.name], status="active", timeout=1400)
 
     traefik_ip = await get_k8s_service_address(model, "traefik-k8s-lb")
     response = requests.get(  # nosec
@@ -144,8 +145,9 @@ async def test_cluster_api_credentials(
         )
         retries = 5
         while retries:
+            url = (f"https://{ip}:55000/security/user/authenticate",)
             response = requests.get(  # nosec
-                f"https://{ip}:55000/security/user/authenticate",
+                url,
                 auth=("wazuh", password),
                 timeout=10,
                 verify=False,
@@ -155,11 +157,13 @@ async def test_cluster_api_credentials(
                 break
 
             logger.warning(
-                "Wazuh API authentication failed with status %s. %s retries remaining.",
+                "Wazuh API authentication failed with status %s. %s retries remaining. %s.",
                 response.status_code,
                 retries,
+                url,
             )
             retries -= 1
+            await asyncio.sleep(1)
         assert response.status_code == 200, f"Wazuh API authentication failed for {unit.name}."
         logger.info("Successfully authenticated to API on unit %s", unit.name)
 

--- a/tox.toml
+++ b/tox.toml
@@ -126,6 +126,14 @@ commands = [
   ],
 ]
 dependency_groups = [ "integration" ]
+passenv = [
+  "HOME",
+  "JUJU_*",
+  "KUBECONFIG",
+  "OPCLI_ARTIFACTS_BUILD_YAML",
+  "OPCLI_PACKAGE",
+  "SPREAD_JOB",
+]
 
 [env.benchmark]
 description = "Benchmark wazuh-server charm reconcile time"

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
 
@@ -727,7 +728,8 @@ name = "ipython"
 version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11'",
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1178,6 +1180,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "opcli"
+version = "0.0.1a2"
+source = { git = "https://github.com/canonical/charm-ci.git#c68e9ac407694597deb27b23db91582c5d1908fa" }
+dependencies = [
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "ruamel-yaml", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -1949,6 +1960,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2202,6 +2222,7 @@ integration = [
     { name = "allure-pytest" },
     { name = "allure-pytest-collection-report" },
     { name = "juju" },
+    { name = "opcli", marker = "python_full_version >= '3.12'" },
     { name = "pyjwt" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2255,6 +2276,7 @@ integration = [
     { name = "allure-pytest", specifier = ">=2.8.18" },
     { name = "allure-pytest-collection-report", git = "https://github.com/canonical/data-platform-workflows?subdirectory=python%2Fpytest_plugins%2Fallure_pytest_collection_report&rev=v24.0.0" },
     { name = "juju" },
+    { name = "opcli", marker = "python_full_version >= '3.12'", git = "https://github.com/canonical/charm-ci.git" },
     { name = "pyjwt" },
     { name = "pytest" },
     { name = "pytest-asyncio" },


### PR DESCRIPTION
## Summary

Migrates the repository from `canonical/operator-workflows` to `canonical/charm-ci` (opcli).

Related to https://github.com/canonical/canonical-repo-automation/pull/935

## Changes

### New files
- `artifacts.yaml` — declares the wazuh-server charm + rock, channel `4.11/edge`, resource→rock mapping
- `spread.yaml` — orchestrates integration tests via spread/opcli
- `concierge.yaml` — provisions microk8s + juju + rockcraft + charmcraft on the test VM

### CI workflows
- `integration_test.yaml` → uses `canonical/charm-ci/.github/workflows/integration-test.yml@main`
- `publish_charm.yaml` → uses `canonical/charm-ci/.github/workflows/publish-artifacts.yml@main`
- `test.yaml` → self-contained (lint + static + unit, no operator-workflows dependency)

### Test fixtures
- Removed manual `--charm-file` / `--wazuh-server-image` pytest options (opcli injects `charm_path` and `resource_images` fixtures)
- Removed VM constraint workaround (`virt-type: virtual-machine`) for OpenSearch — LXD containers are sufficient now
- Also use a single indexer for the integration tests.

### pre_run_script.sh
- Made idempotent: skip juju bootstrap if controller already exists, skip sysctl if already set
- Disable IPv6 on `lxdbr0` before bootstrap so all LXD containers get IPv4 addresses only

### Dependencies
- Added `opcli` to integration dep group with `; python_version >= '3.12'` marker
- Updated `uv.lock` accordingly
- Added opcli passenv to tox.toml integration env
